### PR TITLE
Configuration file support

### DIFF
--- a/docs/dspdfviewer.1
+++ b/docs/dspdfviewer.1
@@ -153,6 +153,11 @@ Switch secondary screen's function
 showing the notes to the audience. Pressing the button again will
 switch back to normal operation.)
 
+.SH CONFIGURATION FILE
+.B ~/.config/dspdfviewer.ini
+You can specify all long command-line options (without leading \-\-) here,
+in a "option=value" format, one per line.
+
 .SH SEE ALSO
 .BR /usr/share/doc/latex-beamer/beameruserguide.pdf.gz
 from the 

--- a/runtimeconfiguration.cpp
+++ b/runtimeconfiguration.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
+#include <fstream>
 
 #ifndef DSPDFVIEWER_VERSION
 #warning DSPDFVIEWER_VERSION was not set by the build system!
@@ -106,10 +107,16 @@ RuntimeConfiguration::RuntimeConfiguration(int argc, char** argv)
   options_description configFileOptions;
   configFileOptions.add(global).add(secondscreen);
   
-  /// TODO Parse config file
-  
   variables_map vm;
   store( command_line_parser(argc,argv).options(commandLineOptions).positional(p).run(), vm);
+  QString configurationFileLocation = qgetenv("HOME").append("/.config/dspdfviewer.ini");
+  {
+    // See if the configuration file exists and is readable
+    std::ifstream cfile( configurationFileLocation.toStdString() );
+    if ( cfile.good() ) {
+      store( parse_config_file( cfile, configFileOptions), vm);
+    }
+  } // close input file
   notify(vm);
   
   if ( vm.count("version") || vm.count("help") ) {


### PR DESCRIPTION
Split from #8

Originally suggested by @mmonaco on 2013-11-16, quoting:

> A config file in the style of OpenVPN or dnsmasq would be nice, they're just fancier ways to specify the long options that are taken on the command line.

This ticket is about the support for a configuration file, that basically takes whatever options the commandline does.

In case of a conflict, order should of course be

command line > configuration file > compile-time default

Most likely, users would configure the helper screen to their liking in the configuration file and mainly use the command line for the `-f` switch (--full-page)