### PR TITLE
[WIP] Rework render factory, dropping the difference between "page" and "thumbnail" renders

### DIFF
--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -64,7 +64,6 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
   audienceWindow.setPageNumberLimits(0, numberOfPages()-1);
 
   sconnect( &renderFactory, SIGNAL(pageRendered(QSharedPointer<RenderedPage>)), &audienceWindow, SLOT(renderedPageIncoming(QSharedPointer<RenderedPage>)));
-  sconnect( &renderFactory, SIGNAL(thumbnailRendered(QSharedPointer<RenderedPage>)), &audienceWindow, SLOT(renderedThumbnailIncoming(QSharedPointer<RenderedPage>)));
   sconnect( &renderFactory, SIGNAL(pdfFileRereadSuccesfully()), this, SLOT(renderPage()));
 
   sconnect( &audienceWindow, SIGNAL(nextPageRequested()), this, SLOT(goForward()));
@@ -87,7 +86,6 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
     secondaryWindow.setPageNumberLimits(0, numberOfPages()-1);
 
     sconnect( &renderFactory, SIGNAL(pageRendered(QSharedPointer<RenderedPage>)), &secondaryWindow, SLOT(renderedPageIncoming(QSharedPointer<RenderedPage>)));
-    sconnect( &renderFactory, SIGNAL(thumbnailRendered(QSharedPointer<RenderedPage>)), &secondaryWindow, SLOT(renderedThumbnailIncoming(QSharedPointer<RenderedPage>)));
 
     sconnect( &secondaryWindow, SIGNAL(nextPageRequested()), this, SLOT(goForward()));
     sconnect( &secondaryWindow, SIGNAL(previousPageRequested()), this, SLOT(goBackward()));

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -253,8 +253,6 @@ void DSPDFViewer::exit()
   secondaryWindow.close();
 }
 
-const QSize DSPDFViewer::thumbnailSize = QSize(200, 100);
-
 PdfRenderFactory* DSPDFViewer::theFactory()
 {
   return &renderFactory;

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -21,6 +21,7 @@
 #include "dspdfviewer.h"
 #include "renderutils.h"
 #include "renderingidentifier.h"
+#include "sconnect.h"
 
 #include <QtGui/QLabel>
 #include <QtGui/QMenu>
@@ -62,22 +63,22 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
 
   audienceWindow.setPageNumberLimits(0, numberOfPages()-1);
 
-  connect( &renderFactory, SIGNAL(pageRendered(QSharedPointer<RenderedPage>)), &audienceWindow, SLOT(renderedPageIncoming(QSharedPointer<RenderedPage>)));
-  connect( &renderFactory, SIGNAL(thumbnailRendered(QSharedPointer<RenderedPage>)), &audienceWindow, SLOT(renderedThumbnailIncoming(QSharedPointer<RenderedPage>)));
-  connect( &renderFactory, SIGNAL(pdfFileRereadSuccesfully()), this, SLOT(renderPage()));
+  sconnect( &renderFactory, SIGNAL(pageRendered(QSharedPointer<RenderedPage>)), &audienceWindow, SLOT(renderedPageIncoming(QSharedPointer<RenderedPage>)));
+  sconnect( &renderFactory, SIGNAL(thumbnailRendered(QSharedPointer<RenderedPage>)), &audienceWindow, SLOT(renderedThumbnailIncoming(QSharedPointer<RenderedPage>)));
+  sconnect( &renderFactory, SIGNAL(pdfFileRereadSuccesfully()), this, SLOT(renderPage()));
 
-  connect( &audienceWindow, SIGNAL(nextPageRequested()), this, SLOT(goForward()));
-  connect( &audienceWindow, SIGNAL(previousPageRequested()), this, SLOT(goBackward()));
-  connect( &audienceWindow, SIGNAL(pageRequested(uint)), this, SLOT(gotoPage(uint)));
+  sconnect( &audienceWindow, SIGNAL(nextPageRequested()), this, SLOT(goForward()));
+  sconnect( &audienceWindow, SIGNAL(previousPageRequested()), this, SLOT(goBackward()));
+  sconnect( &audienceWindow, SIGNAL(pageRequested(uint)), this, SLOT(gotoPage(uint)));
 
-  connect( &audienceWindow, SIGNAL(quitRequested()), this, SLOT(exit()));
-  connect( &audienceWindow, SIGNAL(rerenderRequested()), this, SLOT(renderPage()));
-  connect( &audienceWindow, SIGNAL(restartRequested()), this, SLOT(goToStartAndResetClocks()));
+  sconnect( &audienceWindow, SIGNAL(quitRequested()), this, SLOT(exit()));
+  sconnect( &audienceWindow, SIGNAL(rerenderRequested()), this, SLOT(renderPage()));
+  sconnect( &audienceWindow, SIGNAL(restartRequested()), this, SLOT(goToStartAndResetClocks()));
 
-  connect( &audienceWindow, SIGNAL(screenSwapRequested()), this, SLOT(swapScreens()) );
+  sconnect( &audienceWindow, SIGNAL(screenSwapRequested()), this, SLOT(swapScreens()) );
 
-  connect( &audienceWindow, SIGNAL(blankToggleRequested()), this, SLOT(toggleAudienceScreenBlank()));
-  connect( &audienceWindow, SIGNAL(secondScreenFunctionToggleRequested()), this, SLOT(toggleSecondaryScreenFunction()));
+  sconnect( &audienceWindow, SIGNAL(blankToggleRequested()), this, SLOT(toggleAudienceScreenBlank()));
+  sconnect( &audienceWindow, SIGNAL(secondScreenFunctionToggleRequested()), this, SLOT(toggleSecondaryScreenFunction()));
 
   if ( r.useSecondScreen() )
   {
@@ -85,26 +86,26 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
 
     secondaryWindow.setPageNumberLimits(0, numberOfPages()-1);
 
-    connect( &renderFactory, SIGNAL(pageRendered(QSharedPointer<RenderedPage>)), &secondaryWindow, SLOT(renderedPageIncoming(QSharedPointer<RenderedPage>)));
-    connect( &renderFactory, SIGNAL(thumbnailRendered(QSharedPointer<RenderedPage>)), &secondaryWindow, SLOT(renderedThumbnailIncoming(QSharedPointer<RenderedPage>)));
+    sconnect( &renderFactory, SIGNAL(pageRendered(QSharedPointer<RenderedPage>)), &secondaryWindow, SLOT(renderedPageIncoming(QSharedPointer<RenderedPage>)));
+    sconnect( &renderFactory, SIGNAL(thumbnailRendered(QSharedPointer<RenderedPage>)), &secondaryWindow, SLOT(renderedThumbnailIncoming(QSharedPointer<RenderedPage>)));
 
-    connect( &secondaryWindow, SIGNAL(nextPageRequested()), this, SLOT(goForward()));
-    connect( &secondaryWindow, SIGNAL(previousPageRequested()), this, SLOT(goBackward()));
-    connect( &secondaryWindow, SIGNAL(pageRequested(uint)), this, SLOT(gotoPage(uint)));
+    sconnect( &secondaryWindow, SIGNAL(nextPageRequested()), this, SLOT(goForward()));
+    sconnect( &secondaryWindow, SIGNAL(previousPageRequested()), this, SLOT(goBackward()));
+    sconnect( &secondaryWindow, SIGNAL(pageRequested(uint)), this, SLOT(gotoPage(uint)));
 
-    connect( &secondaryWindow, SIGNAL(quitRequested()), this, SLOT(exit()));
-    connect( &secondaryWindow, SIGNAL(rerenderRequested()), this, SLOT(renderPage()));
-    connect( &secondaryWindow, SIGNAL(restartRequested()), this, SLOT(goToStartAndResetClocks()));
+    sconnect( &secondaryWindow, SIGNAL(quitRequested()), this, SLOT(exit()));
+    sconnect( &secondaryWindow, SIGNAL(rerenderRequested()), this, SLOT(renderPage()));
+    sconnect( &secondaryWindow, SIGNAL(restartRequested()), this, SLOT(goToStartAndResetClocks()));
 
-    connect( &secondaryWindow, SIGNAL(screenSwapRequested()), this, SLOT(swapScreens()) );
+    sconnect( &secondaryWindow, SIGNAL(screenSwapRequested()), this, SLOT(swapScreens()) );
 
-    connect( &secondaryWindow, SIGNAL(blankToggleRequested()), this, SLOT(toggleAudienceScreenBlank()));
-    connect( &secondaryWindow, SIGNAL(secondScreenFunctionToggleRequested()), this, SLOT(toggleSecondaryScreenFunction()));
+    sconnect( &secondaryWindow, SIGNAL(blankToggleRequested()), this, SLOT(toggleAudienceScreenBlank()));
+    sconnect( &secondaryWindow, SIGNAL(secondScreenFunctionToggleRequested()), this, SLOT(toggleSecondaryScreenFunction()));
 
 
-    connect( this, SIGNAL(presentationClockUpdate(QTime)), &secondaryWindow, SLOT(updatePresentationClock(QTime)));
-    connect( this, SIGNAL(slideClockUpdate(QTime)), &secondaryWindow, SLOT(updateSlideClock(QTime)));
-    connect( this, SIGNAL(wallClockUpdate(QTime)), &secondaryWindow, SLOT(updateWallClock(QTime)));
+    sconnect( this, SIGNAL(presentationClockUpdate(QTime)), &secondaryWindow, SLOT(updatePresentationClock(QTime)));
+    sconnect( this, SIGNAL(slideClockUpdate(QTime)), &secondaryWindow, SLOT(updateSlideClock(QTime)));
+    sconnect( this, SIGNAL(wallClockUpdate(QTime)), &secondaryWindow, SLOT(updateWallClock(QTime)));
 
 
   }
@@ -113,7 +114,7 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
 
   clockDisplayTimer.setInterval(TIMER_UPDATE_INTERVAL);
   clockDisplayTimer.start();
-  connect( &clockDisplayTimer, SIGNAL(timeout()), this, SLOT(sendAllClockSignals()));
+  sconnect( &clockDisplayTimer, SIGNAL(timeout()), this, SLOT(sendAllClockSignals()));
   sendAllClockSignals();
 }
 

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -162,22 +162,22 @@ void DSPDFViewer::renderPage()
   audienceWindow.showLoadingScreen(m_pagenumber);
   secondaryWindow.showLoadingScreen(m_pagenumber);
   if ( runtimeConfiguration.showThumbnails() ) {
-    theFactory()->requestThumbnailRendering(m_pagenumber);
+	  /** FIXME: Restore thumbnail rendering */
   }
-  theFactory()->requestPageRendering( toRenderIdent(m_pagenumber, audienceWindow), QThread::HighestPriority);
+  theFactory()->requestPageRendering( toRenderIdent(m_pagenumber, audienceWindow), RenderPriority::CurrentPageAudience);
 
   if ( runtimeConfiguration.useSecondScreen() ) {
-    theFactory()->requestPageRendering( toRenderIdent(m_pagenumber, secondaryWindow), QThread::HighPriority);
+    theFactory()->requestPageRendering( toRenderIdent(m_pagenumber, secondaryWindow), RenderPriority::CurrentPageSecondary);
   }
 
   /** Pre-Render next pages **/
   for ( unsigned i=m_pagenumber; i<m_pagenumber+runtimeConfiguration.prerenderNextPages() && i < numberOfPages() ; i++) {
     if ( runtimeConfiguration.showThumbnails() ) {
-      theFactory()->requestThumbnailRendering(i);
+		/** FIXME: Thumbnail **/
     }
-    theFactory()->requestPageRendering( toRenderIdent(i, audienceWindow));
+    theFactory()->requestPageRendering( toRenderIdent(i, audienceWindow), RenderPriority::PreRenderAudience );
     if ( runtimeConfiguration.useSecondScreen() ) {
-      theFactory()->requestPageRendering( toRenderIdent(i, secondaryWindow));
+      theFactory()->requestPageRendering( toRenderIdent(i, secondaryWindow), RenderPriority::PreRenderSecondary );
     }
   }
 
@@ -186,11 +186,11 @@ void DSPDFViewer::renderPage()
   for ( unsigned i= std::max(m_pagenumber,runtimeConfiguration.prerenderPreviousPages())-runtimeConfiguration.prerenderPreviousPages();
        i<m_pagenumber; i++) {
     if ( runtimeConfiguration.showThumbnails() ) {
-      theFactory()->requestThumbnailRendering(i);
+		/** FIXME: Thumbnails */
     }
-    theFactory()->requestPageRendering(toRenderIdent(i, audienceWindow));
+    theFactory()->requestPageRendering(toRenderIdent(i, audienceWindow), RenderPriority::PreRenderAudience );
     if ( runtimeConfiguration.useSecondScreen() ) {
-      theFactory()->requestPageRendering(toRenderIdent(i, secondaryWindow));
+      theFactory()->requestPageRendering(toRenderIdent(i, secondaryWindow), RenderPriority::PreRenderSecondary );
     }
   }
 

--- a/dspdfviewer.h
+++ b/dspdfviewer.h
@@ -53,11 +53,6 @@ private:
   PDFViewerWindow audienceWindow;
   PDFViewerWindow secondaryWindow;
 
-
-
-public:
-  static const QSize thumbnailSize;
-
 private:
   QImage renderForTarget( QSharedPointer<Poppler::Page> page, QSize targetSize, bool onlyHalf, bool rightHalf=false);
 

--- a/dspdfviewer.h
+++ b/dspdfviewer.h
@@ -67,6 +67,11 @@ private:
 
   RenderingIdentifier toRenderIdent(unsigned int pageNumber, const PDFViewerWindow& window);
 
+  /** Little helper function.
+   * Will request the rendering of the page from the factory
+   */
+  void askFactoryForPage(unsigned pageNumber);
+
 private slots:
   void sendAllClockSignals() const;
 

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -27,9 +27,6 @@
 #include <stdexcept>
 #include <QDebug>
 
-
-static const QSize ThumbnailSize(200,100);
-
 void PdfRenderFactory::pageThreadFinishedRendering(QSharedPointer<RenderedPage> renderedPage)
 {
   {
@@ -177,13 +174,10 @@ void PdfRenderFactory::clearAllCaches()
   // No renders of the current version are taking place, incoming old renders
   // will be ignored.
   currentlyRenderingPages.clear();
-  currentlyRenderingThumbnails.clear();
 
   // Remove the caches. Since we use explicit copy semantics, its safe to empty
   // these.
   renderedPages.clear();
-  renderedThumbnails.clear();
-
 }
 
 int PdfRenderFactory::numberOfPages() const

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -20,6 +20,7 @@
 
 #include "pdfrenderfactory.h"
 #include "renderthread.h"
+#include "sconnect.h"
 
 #include <QMutexLocker>
 #include <QThreadPool>
@@ -70,11 +71,11 @@ PdfRenderFactory::PdfRenderFactory(const QString& filename, const PDFCacheOption
   rewatchFile();
 
   // register the on-change function
-  connect(&fileWatcher, SIGNAL(fileChanged(QString)), this, SLOT(fileOnDiskChanged(QString)));
+  sconnect(&fileWatcher, SIGNAL(fileChanged(QString)), this, SLOT(fileOnDiskChanged(QString)));
 
   // Make sure it re-watches the file
   fileWatcherRewatchTimer.setInterval(1000);
-  connect(&fileWatcherRewatchTimer, SIGNAL(timeout()), this, SLOT(rewatchFile()));
+  sconnect(&fileWatcherRewatchTimer, SIGNAL(timeout()), this, SLOT(rewatchFile()));
   fileWatcherRewatchTimer.start();
 }
 
@@ -102,7 +103,7 @@ void PdfRenderFactory::requestPageRendering(const RenderingIdentifier& originalI
   /* Nobody is working on the page right now. Lets create it. */
 
   RenderThread* t = new RenderThread( documentReference, renderingIdentifier );
-  connect(t, SIGNAL(renderingFinished(QSharedPointer<RenderedPage>)), this, SLOT(pageThreadFinishedRendering(QSharedPointer<RenderedPage>)));
+  sconnect(t, SIGNAL(renderingFinished(QSharedPointer<RenderedPage>)), this, SLOT(pageThreadFinishedRendering(QSharedPointer<RenderedPage>)));
   currentlyRenderingPages.insert(renderingIdentifier);
 
   /** FIXME: priority ignored */

--- a/pdfrenderfactory.h
+++ b/pdfrenderfactory.h
@@ -108,10 +108,8 @@ private:
   QTimer fileWatcherRewatchTimer;
 
   QSet< RenderingIdentifier > currentlyRenderingPages;
-  QSet < int > currentlyRenderingThumbnails;
 
   QCache< RenderingIdentifier, RenderedPage> renderedPages;
-  QCache< int, RenderedPage > renderedThumbnails;
 
   mutable QMutex mutex;
 

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -229,17 +229,6 @@ void PDFViewerWindow::showInformationLine()
   this->bottomArea->show();
 }
 
-void PDFViewerWindow::addThumbnail(uint pageNumber, QImage thumbnail)
-{
-  if ( pageNumber == currentPageNumber-1)
-    previousThumbnail->setPixmap(QPixmap::fromImage(thumbnail));
-  else if ( pageNumber == currentPageNumber )
-    currentThumbnail -> setPixmap(QPixmap::fromImage(thumbnail));
-  else if ( pageNumber == currentPageNumber+1 )
-    nextThumbnail->setPixmap(QPixmap::fromImage(thumbnail));
-}
-
-
 
 void PDFViewerWindow::renderedPageIncoming(QSharedPointer< RenderedPage > renderedPage)
 {
@@ -282,36 +271,6 @@ void PDFViewerWindow::showLoadingScreen(int pageNumberToWaitFor)
   currentThumbnail->setPixmap( QPixmap() );
   nextThumbnail->setPixmap( QPixmap() );
 
-}
-
-
-
-void PDFViewerWindow::renderedThumbnailIncoming(QSharedPointer< RenderedPage > renderedThumbnail)
-{
-  if ( !m_enabled )
-    return;
-
-  /* If a thumbnail for the page we're waiting for is incoming and we have no page at all, its better than nothing */
-  if ( renderedThumbnail->getPageNumber() == currentPageNumber
-    && currentImage.isNull() )
-  {
-    QImage myHalf;
-    if ( myPart == PagePart::LeftHalf )
-    {
-      myHalf = renderedThumbnail->getImage().copy(0, 0, renderedThumbnail->getImage().width()/2, renderedThumbnail->getImage().height());
-    }
-    else if ( myPart == PagePart::RightHalf )
-    {
-      myHalf = renderedThumbnail->getImage().copy(renderedThumbnail->getImage().width()/2, 0, renderedThumbnail->getImage().width()/2, renderedThumbnail->getImage().height());
-    }
-    else if ( myPart == PagePart::FullPage )
-    {
-      myHalf = renderedThumbnail->getImage();
-    }
-    displayImage(myHalf);
-  }
-
-  addThumbnail(renderedThumbnail->getPageNumber(), renderedThumbnail->getImage());
 }
 
 PagePart PDFViewerWindow::getMyPagePart() const

--- a/pdfviewerwindow.h
+++ b/pdfviewerwindow.h
@@ -102,7 +102,6 @@ public:
 
 public slots:
   void renderedPageIncoming( QSharedPointer<RenderedPage> renderedPage);
-  void renderedThumbnailIncoming( QSharedPointer<RenderedPage> renderedThumbnail);
 
   void resizeEvent(QResizeEvent* resizeEvent);
 

--- a/sconnect.h
+++ b/sconnect.h
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 /** secure connect:
  *
  * Quick and dirty hack to check QObject::connect()'s return value

--- a/sconnect.h
+++ b/sconnect.h
@@ -1,0 +1,13 @@
+/** secure connect:
+ *
+ * Quick and dirty hack to check QObject::connect()'s return value
+ */
+template<typename Sender, typename Signal, typename Receiver, typename Slot>
+void sconnect(Sender sender, Signal signal, Receiver receiver, Slot slot) {
+	bool okay = QObject::connect(
+		sender, signal, receiver, slot);
+	if ( ! okay ) {
+		throw std::runtime_error(
+		std::string("QObject::connect failed. sender: ")+signal+" receiver: "+slot);
+	}
+}


### PR DESCRIPTION
This is a prerequisite for #8, since thumbnails will have dynamic sizes just like the pages views do.

The goal is to swap to a priority-based rendering and full control over the threads.

* On boot, spawn N worker threads that wait on a queue (N configurable on command line, default number of processor cores)
* RenderFactory keeps a (Priority-)queue of pages to render and will give them out to the workers one by one. On a page swap, the queue will get cleaned out and once the first worker is ready, will be immediatly available to render the new current page
  * This prevents the system from filling up with threads whole result will get discarded if one just keeps hitting "next page" faster than the system can handle