### PR TITLE
Improve the debugging output

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -23,9 +23,9 @@
  */
 
 #define DEBUGOUT qDebug() << \
- QString("%1:%2 [%3]"). \
+ QString("%1:%2 [%3()]"). \
  arg(QFileInfo(__FILE__).fileName()). \
  arg(QString::number( __LINE__ )). \
- arg( Q_FUNC_INFO ) 
+ arg(__func__)
 
 #endif

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QDebug>
+
+#if QT_NO_DEBUG_OUTPUT
+
+/* Qt is defined to squelch debug output. Simply forward to
+ * qDebug()'s definition.
+ */
+#define DEBUGOUT qDebug()
+
+#else
+
+#include <QtGlobal>
+#include <QFileInfo>
+
+/* We're debugging.
+ * Add crazy mumbo jumbo here.
+ */
+
+
+/** Print filename / line / function info
+ */
+
+#define DEBUGOUT qDebug() << \
+ QString("%1:%2 [%3]"). \
+ arg(QFileInfo(__FILE__).fileName()). \
+ arg(QString::number( __LINE__ )). \
+ arg( Q_FUNC_INFO ) 
+
+#endif

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -41,7 +41,7 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
  audienceWindow(1,  r.useFullPage()? PagePart::FullPage : PagePart::LeftHalf , false, r, "Audience_Window"),
  secondaryWindow(0, r.useFullPage()? PagePart::FullPage : PagePart::RightHalf, true,  r, "Secondary_Window", r.useSecondScreen() )
 {
-  qDebug() << "Starting constructor" ;
+  DEBUGOUT << "Starting constructor" ;
 
   if ( ! r.useSecondScreen() ) {
     secondaryWindow.hide();
@@ -58,7 +58,7 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
     throw std::runtime_error("I was not able to open the PDF document. Sorry.");
   }
 #endif
-  qDebug() << "Connecting audience window";
+  DEBUGOUT << "Connecting audience window";
 
   audienceWindow.setPageNumberLimits(0, numberOfPages()-1);
 
@@ -81,7 +81,7 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
 
   if ( r.useSecondScreen() )
   {
-    qDebug() << "Connecting secondary window";
+    DEBUGOUT << "Connecting secondary window";
 
     secondaryWindow.setPageNumberLimits(0, numberOfPages()-1);
 
@@ -154,9 +154,9 @@ QImage DSPDFViewer::renderForTarget(QSharedPointer< Poppler::Page > page, QSize 
 
 void DSPDFViewer::renderPage()
 {
-  qDebug() << "Requesting rendering of page " << m_pagenumber;
+  DEBUGOUT << "Requesting rendering of page " << m_pagenumber;
   if ( m_pagenumber >= numberOfPages() ) {
-    qDebug() << "Page number out of range, clamping to " << numberOfPages()-1;
+    DEBUGOUT << "Page number out of range, clamping to " << numberOfPages()-1;
     m_pagenumber = numberOfPages()-1;
   }
   audienceWindow.showLoadingScreen(m_pagenumber);
@@ -345,7 +345,7 @@ void DSPDFViewer::toggleAudienceScreenBlank()
 
 void DSPDFViewer::toggleSecondaryScreenFunction()
 {
-  qDebug() << "Swapping second screen";
+  DEBUGOUT << "Swapping second screen";
   switch ( secondaryWindow.getMyPagePart() ) {
     case PagePart::FullPage:
       // Nothing to do

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -30,7 +30,7 @@
 #include <QDesktopWidget>
 #include <qlayout.h>
 
-#include <QDebug>
+#include "debug.h"
 #include <stdexcept>
 
 DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):

--- a/hyperlinkarea.cpp
+++ b/hyperlinkarea.cpp
@@ -20,7 +20,7 @@
 
 #include "hyperlinkarea.h"
 #include <stdexcept>
-#include <QDebug>
+#include "debug.h"
 
 HyperlinkArea::HyperlinkArea(QLabel* imageLabel, const AdjustedLink& link): QLabel(), targetPage(link.targetPageNumber())
 {

--- a/hyperlinkarea.cpp
+++ b/hyperlinkarea.cpp
@@ -58,13 +58,13 @@ HyperlinkArea::HyperlinkArea(QLabel* imageLabel, const AdjustedLink& link): QLab
   setCursor( Qt::PointingHandCursor );
   
   
-  qDebug() << "Added an hyperlink to" << text() << "at" << geometry();
+  DEBUGOUT << "Added an hyperlink to" << text() << "at" << geometry();
 }
 
 
 void HyperlinkArea::mousePressEvent(QMouseEvent* ev)
 {
-  qDebug() << "Hyperlink clicked" << ev << "Target page" << targetPage;
+  DEBUGOUT << "Hyperlink clicked" << ev << "Target page" << targetPage;
   
   emit gotoPageRequested(targetPage);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@
 
 
 #include <QtGui/QApplication>
-#include <QDebug>
+#include "debug.h"
 #include "dspdfviewer.h"
 #include "runtimeconfiguration.h"
 #include <stdexcept>

--- a/pdfdocumentreference.cpp
+++ b/pdfdocumentreference.cpp
@@ -3,7 +3,7 @@
 
 #include <stdexcept>
 #include <QFile>
-#include <QDebug>
+#include "debug.h"
 
 QSharedPointer< Poppler::Document > PDFDocumentReference::popplerDocument() const
 {

--- a/pdfdocumentreference.cpp
+++ b/pdfdocumentreference.cpp
@@ -10,12 +10,12 @@ QSharedPointer< Poppler::Document > PDFDocumentReference::popplerDocument() cons
   QSharedPointer<Poppler::Document> m_document;
 
   if ( cacheOption() == PDFCacheOption::rereadFromDisk ) {
-    qDebug() << "Trying to build a Poppler::Document from file" << filename();
+    DEBUGOUT << "Trying to build a Poppler::Document from file" << filename();
     QSharedPointer<Poppler::Document> diskDocument( Poppler::Document::load(filename()) );
     m_document.swap(diskDocument);
   }
   else if ( cacheOption() == PDFCacheOption::keepPDFinMemory ) {
-    qDebug() << "Trying to build a document from" << fileContents_.size() << "byte memory cache";
+    DEBUGOUT << "Trying to build a document from" << fileContents_.size() << "byte memory cache";
     QSharedPointer<Poppler::Document> memoryDocument( Poppler::Document::loadFromData(fileContents_) );
     m_document.swap(memoryDocument);
   }
@@ -38,11 +38,11 @@ filename_(theFilename),
 cacheOption_(theCacheOption)
 {
   if ( cacheOption() == PDFCacheOption::keepPDFinMemory ) {
-    qDebug() << "Reading file into memory";
+    DEBUGOUT << "Reading file into memory";
     QFile file(filename());
     file.open(QIODevice::ReadOnly);
     fileContents_ = file.readAll();
-    qDebug() << fileContents_.size() << "bytes read";
+    DEBUGOUT << fileContents_.size() << "bytes read";
   }
 }
 const PDFCacheOption& PDFDocumentReference::cacheOption() const

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -24,7 +24,7 @@
 #include <QMutexLocker>
 #include <QThreadPool>
 #include <stdexcept>
-#include <QDebug>
+#include "debug.h"
 
 
 static const QSize ThumbnailSize(200,100);

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -154,10 +154,10 @@ void PdfRenderFactory::requestThumbnailRendering(int pageNumber)
 
 void PdfRenderFactory::fileOnDiskChanged(const QString& filename)
 {
-  qDebug() << "File" << filename << "has changed on disk";
+  DEBUGOUT << "File" << filename << "has changed on disk";
 
   if ( filename != documentReference.filename() ) {
-    qDebug() << "Ignoring that file.";
+    DEBUGOUT << "Ignoring that file.";
     return;
   }
 
@@ -180,7 +180,7 @@ void PdfRenderFactory::fileOnDiskChanged(const QString& filename)
 	// If they are *identical*, we can skip the reloading.
 	
 	if( documentReference == newDoc ) {
-	  qDebug() << "The new document compares identical to the old one, not doing anything.";
+	  DEBUGOUT << "The new document compares identical to the old one, not doing anything.";
 	  return;
 	}
       }
@@ -199,7 +199,7 @@ void PdfRenderFactory::fileOnDiskChanged(const QString& filename)
 
     emit pdfFileRereadSuccesfully();
   } catch( std::runtime_error& e) {
-    qDebug() << "Unable to read the new reference. keeping the old one.";
+    DEBUGOUT << "Unable to read the new reference. keeping the old one.";
     emit pdfFileRereadFailed();
   }
 }

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -126,11 +126,11 @@ void PDFViewerWindow::wheelEvent(QWheelEvent* e)
 
     if ( e->delta() > 0 )
     {
-      qDebug() << "Back";
+      DEBUGOUT << "Back";
       emit previousPageRequested();
     }
     else{
-      qDebug() << "Next";
+      DEBUGOUT << "Next";
       emit nextPageRequested();
     }
 }
@@ -329,8 +329,8 @@ void PDFViewerWindow::resizeEvent(QResizeEvent* resizeEvent)
     return;
 
   QWidget::resizeEvent(resizeEvent);
-  qDebug() << "Resize event" << resizeEvent;
-  qDebug() << "Resized from" << resizeEvent->oldSize() << "to" << resizeEvent->size() << ", requesting re-render.";
+  DEBUGOUT << "Resize event" << resizeEvent;
+  DEBUGOUT << "Resized from" << resizeEvent->oldSize() << "to" << resizeEvent->size() << ", requesting re-render.";
   emit rerenderRequested();
 }
 
@@ -426,7 +426,7 @@ void PDFViewerWindow::setBlank(const bool blank)
     return;
   /* State changes. request re-render */
   this->blank = blank;
-  qDebug() << "Changing blank state to" << blank;
+  DEBUGOUT << "Changing blank state to" << blank;
   if ( blank ) {
     imageLabel->clear();
   } else {
@@ -454,8 +454,8 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
       continue;
     }
     const Poppler::Link::LinkType& type = link.link()->linkType();
-    qDebug() << "Link Received! " ;
-    qDebug() << "Link Area: " << link.linkArea();
+    DEBUGOUT << "Link Received! " ;
+    DEBUGOUT << "Link Area: " << link.linkArea();
     if ( type == Poppler::Link::LinkType::Goto ) {
       // type is Goto. Bind it to imageLabel
       const Poppler::LinkGoto& linkGoto = dynamic_cast<const Poppler::LinkGoto&>( * link.link() );
@@ -481,7 +481,7 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
 
 void PDFViewerWindow::linkClicked(uint targetNumber)
 {
-  qDebug() << "Hyperlink detected";
+  DEBUGOUT << "Hyperlink detected";
   emit pageRequested(targetNumber);
 }
 

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -24,7 +24,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
-#include <QDebug>
+#include "debug.h"
 #include <QInputDialog>
 #include <QMessageBox>
 

--- a/renderthread.cpp
+++ b/renderthread.cpp
@@ -21,7 +21,7 @@
 #include "renderthread.h"
 #include "renderutils.h"
 #include "adjustedlink.h"
-#include <QDebug>
+#include "debug.h"
 
 RenderThread::RenderThread(PDFDocumentReference theDocument, RenderingIdentifier renderIdent):
   QObject(),

--- a/renderthread.cpp
+++ b/renderthread.cpp
@@ -33,7 +33,7 @@ RenderThread::RenderThread(PDFDocumentReference theDocument, RenderingIdentifier
 
 void RenderThread::run()
 {
-  qDebug() << "RenderThread for" << renderMe << "started";
+  DEBUGOUT << "RenderThread for" << renderMe << "started";
   QImage renderImage = RenderUtils::renderPagePart(m_page.page, renderMe.requestedPageSize(), renderMe.pagePart());
   if ( renderImage.isNull() )
   {
@@ -56,7 +56,7 @@ void RenderThread::run()
     }
   }
   QSharedPointer<RenderedPage> renderResult(new RenderedPage( renderImage, links, renderMe ));
-  qDebug() << "RenderThread for" << renderMe << "successful, image has size" << renderResult->getImage().size();
+  DEBUGOUT << "RenderThread for" << renderMe << "successful, image has size" << renderResult->getImage().size();
   emit renderingFinished(renderResult);
 }
 

--- a/renderthread.cpp
+++ b/renderthread.cpp
@@ -33,11 +33,11 @@ RenderThread::RenderThread(PDFDocumentReference theDocument, RenderingIdentifier
 
 void RenderThread::run()
 {
-  qDebug() << "RenderThread for " << renderMe << " started";
+  qDebug() << "RenderThread for" << renderMe << "started";
   QImage renderImage = RenderUtils::renderPagePart(m_page.page, renderMe.requestedPageSize(), renderMe.pagePart());
   if ( renderImage.isNull() )
   {
-    qDebug() << "RenderThread for " << renderMe << " failed";
+    qWarning() << "RenderThread for" << renderMe << "failed";
     QSharedPointer<RenderingIdentifier> ri( new RenderingIdentifier(renderMe) );
     emit renderingFailed(ri);
     return;
@@ -56,7 +56,7 @@ void RenderThread::run()
     }
   }
   QSharedPointer<RenderedPage> renderResult(new RenderedPage( renderImage, links, renderMe ));
-  qDebug() << "RenderThread for " << renderMe << " successful, image has size " << renderResult->getImage().size();
+  qDebug() << "RenderThread for" << renderMe << "successful, image has size" << renderResult->getImage().size();
   emit renderingFinished(renderResult);
 }
 

--- a/renderutils.cpp
+++ b/renderutils.cpp
@@ -20,7 +20,7 @@
 
 #include "renderutils.h"
 
-#include <QDebug>
+#include "debug.h"
 #include <stdexcept>
 
 QImage RenderUtils::renderPagePart(QSharedPointer< Poppler::Page > page, QSize targetSize, PagePart whichPart)


### PR DESCRIPTION
Improve the debugging output throughout, making it more readable and useful.

If I'm compiling with `cmake -DCMAKE_BUILD_TYPE=Debug` I want to see not only *what* is going on, but also where.

Following should be contained in every debug output statement:
* Function name (if known)
* File name (without path)
* Line number

