### PR TITLE
Allow file chooser when started without a PDF file parameter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,7 @@
 #include "runtimeconfiguration.h"
 #include <stdexcept>
 #include <QMessageBox>
+#include <QFileDialog>
 
 int main(int argc, char** argv)
 {
@@ -39,9 +40,13 @@ int main(int argc, char** argv)
 		*/
 		qRegisterMetaType< QSharedPointer<RenderedPage> >("QSharedPointer<RenderedPage>");
 		RuntimeConfiguration rc(argc, argv);
-		
+
+		if ( ! rc.filePathDefined() ) {
+			rc.filePath( QFileDialog::getOpenFileName(
+				nullptr, "Load PDF from disk", QString(), "PDF (*.pdf)" ).toStdString() );
+		}
+
 		DSPDFViewer foo( rc );
-		
 		return app.exec();
 	} catch ( std::exception& e ) {
 		QMessageBox errorMsg;

--- a/runtimeconfiguration.cpp
+++ b/runtimeconfiguration.cpp
@@ -139,10 +139,6 @@ RuntimeConfiguration::RuntimeConfiguration(int argc, char** argv)
     exit(1);
   }
 
-  if ( 0 == vm.count("pdf-file") ) {
-    throw std::runtime_error("You did not specify a PDF-File to display");
-  }
-
   m_useFullPage = ( 0 < vm.count("full-page") );
 
   /** Implied options */
@@ -162,12 +158,16 @@ RuntimeConfiguration::RuntimeConfiguration(int argc, char** argv)
 
 string RuntimeConfiguration::filePath() const
 {
+  if ( m_filePath.empty() ) {
+    throw noFileNameException();
+  }
+
   return m_filePath;
 }
 
 QString RuntimeConfiguration::filePathQString() const
 {
-  return QString::fromStdString(m_filePath);
+  return QString::fromStdString( filePath() );
 }
 
 bool RuntimeConfiguration::useFullPage() const
@@ -218,4 +218,8 @@ bool RuntimeConfiguration::cachePDFToMemory() const
 bool RuntimeConfiguration::hyperlinkSupport() const
 {
   return m_hyperlinkSupport;
+}
+
+noFileNameException::noFileNameException():
+	logic_error("You did not specify a PDF-File to display.") {
 }

--- a/runtimeconfiguration.cpp
+++ b/runtimeconfiguration.cpp
@@ -220,6 +220,16 @@ bool RuntimeConfiguration::hyperlinkSupport() const
   return m_hyperlinkSupport;
 }
 
+void RuntimeConfiguration::filePath(const std::string& newPath )
+{
+	m_filePath = newPath;
+}
+
+bool RuntimeConfiguration::filePathDefined() const
+{
+	return ! m_filePath.empty();
+}
+
 noFileNameException::noFileNameException():
 	logic_error("You did not specify a PDF-File to display.") {
 }

--- a/runtimeconfiguration.h
+++ b/runtimeconfiguration.h
@@ -94,10 +94,12 @@ public:
 
   bool useFullPage() const;
 
+  bool filePathDefined() const;
+
   QString filePathQString() const;
 
   std::string filePath() const;
-  void filePath(std::string newPath);
+  void filePath(const std::string& newPath);
 
   bool showPresenterArea() const;
   bool showWallClock() const;

--- a/runtimeconfiguration.h
+++ b/runtimeconfiguration.h
@@ -22,6 +22,11 @@
 #define RUNTIMECONFIGURATION_H
 #include <string>
 #include <QString>
+#include <stdexcept>
+
+struct noFileNameException: public std::logic_error {
+	noFileNameException();
+};
 
 class RuntimeConfiguration
 {
@@ -92,6 +97,7 @@ public:
   QString filePathQString() const;
 
   std::string filePath() const;
+  void filePath(std::string newPath);
 
   bool showPresenterArea() const;
   bool showWallClock() const;


### PR DESCRIPTION
If dspdfviewer is launched without a PDF file on the command line, spawn a Qt File Chooser dialog, allowing the user to pick one from disk.