### PR TITLE
Rework version number embedding logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,9 @@ install:
  - sudo apt-get update
  - sudo apt-get install --no-install-recommends devscripts equivs
  - sudo mk-build-deps --install --remove
-script: debuild -tc -uc -us
+
+# test both fallback and debian specific build system
+
+script:
+ - ( TEMPDIR=$(mktemp -d) && git archive HEAD | tar -C $TEMPDIR -xv && mkdir "$TEMPDIR/build" && cd "$TEMPDIR/build" && cmake .. && make
+ - debuild -tc -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
 # test both fallback and debian specific build system
 
 script:
- - ( TEMPDIR=$(mktemp -d) && git archive HEAD | tar -C $TEMPDIR -xv && mkdir "$TEMPDIR/build" && cd "$TEMPDIR/build" && cmake .. && make
+ - ( TEMPDIR=$(mktemp -d) && git archive HEAD | tar -C $TEMPDIR -xv && mkdir "$TEMPDIR/build" && cd "$TEMPDIR/build" && cmake .. && make )
  - debuild -tc -uc -us

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,38 +65,47 @@ else()
   add_definitions(-DQT_NO_DEBUG_OUTPUT)
 endif()
 
-if( NOT "${DSPDFVIEWER_VERSION}" MATCHES "^$" )
-  # Not-Empty version given on the command line
-  message(STATUS "Using the version number ${DSPDFVIEWER_VERSION} specified on the command line.")
-else()
-  # We dont have a version number given by the build system.
-  # Try to figure it out first by asking git (only works for in-tree source builds)
-  execute_process(COMMAND git describe
-	  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_DESCRIBE_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if( NOT "${GIT_DESCRIBE_VERSION}" MATCHES "^$" )
-    message(STATUS "Using version number ${GIT_DESCRIBE_VERSION} as defined by git-describe.")
-    set(DSPDFVIEWER_VERSION ${GIT_DESCRIBE_VERSION})
-  else()
-	# use the standard utility dpkg-parsechangelog to get the version number
-	execute_process(COMMAND dpkg-parsechangelog
+### Version-number inclusion logic.
+
+# Rationale: dspdfviewer --version should print something meaningful
+# Especially on builds from git, it should include the git revision.
+
+if( DSPDFVIEWER_VERSION )
+  # Not-Empty version given on the command line. This has absolute priority.
+  message(STATUS "Embedding the version number ${DSPDFVIEWER_VERSION} specified on the command line.")
+endif()
+
+if( NOT DSPDFVIEWER_VERSION AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" )
+	# We don't have a version number yet, but
+	# this looks like a checkout from git.
+	# Ask "git describe" for a version number.
+	message(STATUS "Building from a git clone, using git describe for a version number.")
+	execute_process(COMMAND git describe
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-		OUTPUT_VARIABLE DEBIANCHANGELOG OUTPUT_STRIP_TRAILING_WHITESPACE)
-	# grep for the line with "Version: "
-	string(REGEX MATCH "Version: [^ \r\n\t]*" DEBIANVERSION "${DEBIANCHANGELOG}")
-	# strip "Version: "
-	string(REPLACE "Version: " "" DEBIANVERSION "${DEBIANVERSION}")
-    if ( NOT "${DEBIANVERSION}" MATCHES "^$" )
-      message(STATUS "Using version number ${DEBIANVERSION} as parsed from debian/changelog's first entry.")
-      set(DSPDFVIEWER_VERSION ${DEBIANVERSION})
-    # FIXME: Provide an else if checking directory name (if downloaded from github it will be named dspdfviewer-1.12)
-    else()
-      # Try to infer the version number from the debian/changelog source file
-      message(WARNING "Could not correctly determine the version number of the program. Please pass -DDSPDFVIEWER_VERSION=1.2.3.4.5 to the cmake command.")
-      # TODO Keep me updated!
-	  set(DSPDFVIEWER_VERSION "v1.13")
-    endif()
-  endif()
+		OUTPUT_VARIABLE GIT_DESCRIBE_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+	# Check if it gave something back
+	if( NOT "${GIT_DESCRIBE_VERSION}" MATCHES "^$" )
+		message(STATUS "Embedding version number ${GIT_DESCRIBE_VERSION} as defined by git-describe.")
+		set(DSPDFVIEWER_VERSION ${GIT_DESCRIBE_VERSION})
+	endif()
+endif()
+
+# Debian specific: Use dpkg-parsechangelog
+if( NOT DSPDFVIEWER_VERSION AND $ENV{DEBIAN_PACKAGE_VERSION})
+	# This is useful if jenkins or launchpad compile the package.
+	set(DSPDFVIEWER_VERSION $ENV{DEBIAN_PACKAGE_VERSION})
+	message( STATUS "Embedding version number ${DSPDFVIEWER_VERSION} as provided by the debian build system.")
+endif()
+
+if( NOT DSPDFVIEWER_VERSION )
+	# We still don't know version number to embed.
+	# Use default
+
+	# TODO: Keep me updated!
+	set(DSPDFVIEWER_VERSION "1.13")
+	message(STATUS "Embedding version number ${DSPDFVIEWER_VERSION}. If you want to override this, "
+		"for example to embed the git revision you built from, please pass "
+		"-DDSPDFVIEWER_VERSION=1.2.3.4.5 to the cmake command.")
 endif()
 
 if( NOT "${DSPDFVIEWER_VERSION}" MATCHES "^$" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if( NOT DSPDFVIEWER_VERSION AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" )
 endif()
 
 # Debian specific: Use dpkg-parsechangelog
-if( NOT DSPDFVIEWER_VERSION AND $ENV{DEBIAN_PACKAGE_VERSION})
+if( NOT DSPDFVIEWER_VERSION AND ENV{DEBIAN_PACKAGE_VERSION})
 	# This is useful if jenkins or launchpad compile the package.
 	set(DSPDFVIEWER_VERSION $ENV{DEBIAN_PACKAGE_VERSION})
 	message( STATUS "Embedding version number ${DSPDFVIEWER_VERSION} as provided by the debian build system.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if( NOT DSPDFVIEWER_VERSION )
 	# Use default
 
 	# TODO: Keep me updated!
-	set(DSPDFVIEWER_VERSION "1.13")
+	set(DSPDFVIEWER_VERSION "1.13-rc0")
 	message(STATUS "Embedding version number ${DSPDFVIEWER_VERSION}. If you want to override this, "
 		"for example to embed the git revision you built from, please pass "
 		"-DDSPDFVIEWER_VERSION=1.2.3.4.5 to the cmake command.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,12 @@ else()
     if ( NOT "${DEBIANVERSION}" MATCHES "^$" )
       message(STATUS "Using version number ${DEBIANVERSION} as parsed from debian/changelog's first entry.")
       set(DSPDFVIEWER_VERSION ${DEBIANVERSION})
+    # FIXME: Provide an else if checking directory name (if downloaded from github it will be named dspdfviewer-1.12)
     else()
       # Try to infer the version number from the debian/changelog source file
-      message(WARNING "Could not determine the version number of the program. Please pass -DDSPDFVIEWER_VERSION=1.2.3.4.5 to the cmake command.")
+      message(WARNING "Could not correctly determine the version number of the program. Please pass -DDSPDFVIEWER_VERSION=1.2.3.4.5 to the cmake command.")
+      # TODO Keep me updated!
+	  set(DSPDFVIEWER_VERSION "v1.13")
     endif()
   endif()
 endif()

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,9 @@
 # dh-make output file, you may use that output file without restriction.
 # This special exception was added by Craig Small in version 0.37 of dh-make.
 
+# provide debian version number to the build system
+export DEBIAN_PACKAGE_VERSION=$(shell dpkg-parsechangelog --show-field Version)
+
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 


### PR DESCRIPTION
Rather than failing the build when it can't determine a version number, the build system should have a fallback (which should probably be something like `vNEXT-rc`, so bug reports built from that build system can be identified).

Any system-specific versionings (like debians changelog) should be parsed in the system-specific build instruction, and the result passed as environment variable or similar. cmake can then check its presense.

Order or precedence (First one that produces a non-empty string wins)

1. `cmake -DDSPDFVIEWER_VERSION=1.2.3.4`
2. If the directory `.git` exists, run `git describe`
3. System specific, given in environment variable
4. fallback version number, in `CMakeLists.txt`.
  * Update this on a release tag to the current version number, and immediatly after to "something higher".

The fallback mechanic can be tested by doing something along the lines of
```bash
TEMPDIR=$(mktemp -d)
git archive HEAD | tar -C $TEMPDIR -x && \
cd $TEMPDIR && \
mkdir build && \
cd build && \
cmake .. && \
make
```