### PR TITLE
Clean up debian/ directory

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Build-Depends: g++ (>= 4:4.6),
  debhelper (>= 7.3.0), cmake,
  libpoppler-qt4-dev,
  libboost-program-options-dev,
- hardening-wrapper,
  lsb-release
 # The project needs a c++11 compiler.
 # Its known to work with g++ 4.6 and up
@@ -27,10 +26,6 @@ Build-Depends: g++ (>= 4:4.6),
 #
 # - libboost-program-options-dev
 # the boost program options to parse command line parameters
-#
-# - hardening-wrapper
-# And the hardening-wrapper because lintian told me to make the build
-# safer.
 #
 # - lsb-release
 # This is needed for the switch in the debian/rules file checking

--- a/debian/rules
+++ b/debian/rules
@@ -11,9 +11,12 @@ export DH_VERBOSE=1
 
 # Make sure to NOT use any flags from environment and only use the standard
 # debian build flags.
+#
+# include CPPFLAGS in CFLAGS, this is a cmake workaround found on
+# https://wiki.debian.org/Hardening#Notes_for_packages_using_CMake
 CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
-CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
-CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS)
+CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) $(CPPFLAGS)
+CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS) $(CPPFLAGS)
 LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -16,21 +16,5 @@ CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
 CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS)
 LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
-# Hacks for ubuntu lucid
-CODENAME=$(shell lsb_release --codename --short)
-
-# If we compile on ubuntu lucid, g++ wont be aliased to
-# g++-4.6 even though we pulled from the ppa (by build-depends)
-# so we need to force the compiler
-ifeq ($(CODENAME),lucid)
-export CC=gcc-4.6
-export CXX=g++-4.6
-export LD=ld-4.6
-# since we dont have the libstdc++ in a high enough version on lucid,
-# we statically link. Not optimal, yes. But it does work and
-# the user does not have to install it generally for every program.
-export LDFLAGS:=$(LDFLAGS) -static-libstdc++
-endif
-
 %:
 	dh $@

--- a/debian/rules
+++ b/debian/rules
@@ -9,13 +9,11 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
-export DEB_BUILD_HARDENING=1
-
-# Make sure to NOT eat any flags from environment and only use the standard
+# Make sure to NOT use any flags from environment and only use the standard
 # debian build flags.
 CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
-CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) $(CPPFLAGS)
-CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS) $(CPPFLAGS)
+CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
+CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS)
 LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
 # Hacks for ubuntu lucid

--- a/debian/rules
+++ b/debian/rules
@@ -9,15 +9,18 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
+# enable hardening
+export DEB_BUILD_HARDENING=1
+
 # Make sure to NOT use any flags from environment and only use the standard
 # debian build flags.
 #
 # include CPPFLAGS in CFLAGS, this is a cmake workaround found on
 # https://wiki.debian.org/Hardening#Notes_for_packages_using_CMake
-CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
-CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) $(CPPFLAGS)
-CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS) $(CPPFLAGS)
-LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
+export CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
+export CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) $(CPPFLAGS)
+export CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS) $(CPPFLAGS)
+export LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
 %:
 	dh $@


### PR DESCRIPTION
* Compiling on current sid complains that `hardening-wrapper` is outdated and should be replaced with dpkg-buildflags.
  * Right now, the resulting binary will *not* be hardened -- something's off here.
* Drop ubuntu lucid hacks, since lucid is [end of life] and launchpad doesn't build for it anymore anyway.

Goal: No more lintian warnings, while still compiling on wheezy, jessie, sid, and all the currently-supported ubuntus (12.04 and up)

[end of life]: http://www.ubuntu.com/info/release-end-of-life