### PR TITLE
Hiding console

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -22,6 +22,10 @@
 /** Print filename / line / function info
  */
 
+#if defined(_MSC_VER)
+#define __func__ __FUNCTION__
+#endif
+
 #define DEBUGOUT qDebug() << \
  QString("%1:%2 [%3()]"). \
  arg(QFileInfo(__FILE__).fileName()). \

--- a/main.cpp
+++ b/main.cpp
@@ -27,8 +27,21 @@
 #include <QMessageBox>
 #include <QFileDialog>
 
+#ifdef _WIN32
+#pragma comment(linker, "/SUBSYSTEM:windows")
+#include <Windows.h>
+
+int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmdShow)
+{
+	int argc = __argc;
+	#define argv __argv
+
+#else
+
 int main(int argc, char** argv)
 {
+
+#endif
 	QApplication app(argc, argv);
 	app.setApplicationName( "dspdfviewer" );
 	app.setApplicationVersion( DSPDFVIEWER_VERSION );

--- a/main.cpp
+++ b/main.cpp
@@ -27,7 +27,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 
-#ifdef _WIN32
+#if defined ( _WIN32 ) && defined ( NDEBUG )
 #pragma comment(linker, "/SUBSYSTEM:windows")
 #include <Windows.h>
 


### PR DESCRIPTION
Changed application type to Windows GUI so that the console windows does not show up automatically.
Note that this also means that there will never be a console or output to a console window in any case. If you used the console at some point to print a message without at the same time giving a window popup, this message will not be seen.