### PR TITLE
Revert _USE_CXX11_ABI related changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ sudo: required
 install:
  - sudo apt-get update
  - sudo apt-get install --install-recommends sbuild
- - sudo mkdir /root/.gnupg
  - sudo sbuild-adduser $(whoami)
  - sudo sbuild-update --keygen
- - sudo sbuild-createchroot sid $(mktemp -d) http://httpredir.debian.org/debian
+ - sudo sbuild-createchroot --keyring '' sid $(mktemp -d) http://httpredir.debian.org/debian
 # This will create a sid chroot and try to build inside the chroot.
 script:
  - sudo sbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: cpp
 sudo: required
 install:
  - sudo apt-get update
- - sudo apt-get install --install-recommends sbuild
- - sudo sbuild-adduser $(whoami)
- - sudo sbuild-update --keygen
- - sudo sbuild-createchroot --keyring '' sid $(mktemp -d) http://httpredir.debian.org/debian
-# This will create a sid chroot and try to build inside the chroot.
+ - sudo apt-get install --no-install-recommends devscripts equivs
+ - sudo mk-build-deps --install --remove
+
+# test both fallback and debian specific build system
+
 script:
- - sudo sbuild
+ - ( TEMPDIR=$(mktemp -d) && git archive HEAD | tar -C $TEMPDIR -xv && mkdir "$TEMPDIR/build" && cd "$TEMPDIR/build" && cmake .. && make )
+ - debuild -tc -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 sudo: required
 install:
  - sudo apt-get update
- - sudo apt-get install --no-install-recommends sbuild
+ - sudo apt-get install --install-recommends sbuild
  - sudo mkdir /root/.gnupg
  - sudo sbuild-adduser $(whoami)
  - sudo sbuild-update --keygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: cpp
 sudo: required
 install:
  - sudo apt-get update
- - sudo apt-get install --no-install-recommends devscripts equivs
- - sudo mk-build-deps --install --remove
-
-# test both fallback and debian specific build system
-
+ - sudo apt-get install --no-install-recommends sbuild
+ - sudo mkdir /root/.gnupg
+ - sudo sbuild-adduser $(whoami)
+ - sudo sbuild-update --keygen
+ - sudo sbuild-createchroot sid $(mktemp -d) http://httpredir.debian.org/debian
+# This will create a sid chroot and try to build inside the chroot.
 script:
- - ( TEMPDIR=$(mktemp -d) && git archive HEAD | tar -C $TEMPDIR -xv && mkdir "$TEMPDIR/build" && cd "$TEMPDIR/build" && cmake .. && make )
- - debuild -tc -uc -us
+ - sudo sbuild

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,6 @@ else()
   add_definitions(-DQT_NO_DEBUG_OUTPUT)
 endif()
 
-if ( DISABLE_CXX11_ABI )
-	add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-endif()
-
 ### Version-number inclusion logic.
 
 # Rationale: dspdfviewer --version should print something meaningful

--- a/debian/rules
+++ b/debian/rules
@@ -25,8 +25,5 @@ export CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) $(CPPFLAGS)
 export CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS) $(CPPFLAGS)
 export LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
-override_dh_auto_configure:
-	dh_auto_configure -- -DDISABLE_CXX11_ABI=1
-
 %:
 	dh $@


### PR DESCRIPTION
While trying to build a proper debian package #55 I discovered a Fails-To-Build-From-Source Bug in debian sid, but not any other.

Right now, if I explicitely state that I *don't* want the cxx11 ABI, the compile goes through cleanly. However, it is possible that the problem is on the boost side since the error message one gets - see https://travis-ci.org/dannyedel/dspdfviewer/builds/73694510 for a complete build log - seems to suggest that boost's header exports a `program_options` with the new `std::__cxx11::basic_string` as a template parameter, but gcc's linker can't find it.

As soon as a clean-room (`sbuild`) build on `sid` works again, merge this pull request but ***remember to revert the .travis.yml*** to the "just use the current ubuntu environment to build quickly" mode for near-instant feedback. As soon as this specific bug is over, there's no reason to use more I/O and cpu time than absolutely needed.