### PR TITLE
Qt5: Depend on version 5.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
     - BUILDSYSTEM=outside
 matrix:
   fast_finish: true
-  allow_failures:
-    - compiler: clang
-      env: CMAKE_PARAMETERS="-DUseQtFive=ON"
 install:
  - _travis/install_dependencies
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: cpp
 sudo: required
+services:
+    - docker
 compiler:
     - clang
     - gcc
 env:
     - CMAKE_PARAMETERS="-DUseQtFive=ON"
     - CMAKE_PARAMETERS="-DUseQtFive=OFF"
-    - BUILDSYSTEM=debian DEPSYSTEM=debian
-    - BUILDSYSTEM=outside
 matrix:
   fast_finish: true
 install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ option(UseQtFive "Build with Qt5 and libpoppler-qt5" OFF)
 if(UseQtFive)
 	#qt5
 	message(STATUS "Using Qt5 and libpoppler-qt5")
-	find_package(Qt5Core REQUIRED)
+	find_package(Qt5Core 5.1.1 REQUIRED)
+	# On lower versions, QTBUG-32100 prevents compilation at least on clang
+	# https://bugreports.qt.io/browse/QTBUG-32100
 	find_package(Qt5Gui REQUIRED)
 	find_package(Qt5Widgets REQUIRED)
 	find_library(POPPLER NAMES poppler-qt5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	add_definitions(-Wno-padded)
 	#   in release mode: Unrechable code / Macro expansion (these stem from QDEBUG)
 	if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug" )
-		add_definitions(-Wno-unreachable-code -Wno-unreachable-code -Wno-disabled-macro-expansion)
+		add_definitions(-Wno-unreachable-code -Wno-disabled-macro-expansion)
 	endif()
+	#   Qt's moc (Meta Object Compiler) generates code that triggers warnings
+	#   about undefined behaviours.
+
+	#   So don't set Werror for it.
+	add_definitions(-Wno-error=undefined-reinterpret-cast)
 else()
 	message(WARNING "Compiling with a Non-GNU compiler. A lot less warnings will be output, so more coding errors might go undetected.")
 endif()

--- a/_travis/install_dependencies
+++ b/_travis/install_dependencies
@@ -20,9 +20,6 @@ if [ "$DEPSYSTEM" = "debian" ] ; then
 else
 	DEPS="libboost-program-options-dev"
 	if [ "$CMAKE_PARAMETERS" = "-DUseQtFive=ON" ] ; then
-		echo "Adding dannyedel ppa"
-		sudo add-apt-repository ppa:dannyedel/libpoppler-qt5-backports -y
-		sudo add-apt-repository ppa:ubuntu-sdk-team/ppa -y
 		DEPS="${DEPS} libpoppler-qt5-dev qtbase5-dev"
 	else
 		DEPS="${DEPS} libpoppler-qt4-dev"

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -377,9 +377,7 @@ QString PDFViewerWindow::timeToString(const QTime & time) const
 
 QString PDFViewerWindow::timeToString(int milliseconds) const
 {
-  QTime time;
-  time.addMSecs(milliseconds);
-  return timeToString(time);
+  return timeToString(QTime(0,0).addMSecs(milliseconds));
 }
 
 


### PR DESCRIPTION
Depend on Qt >= 5.1.1 because of QT Bug 32100:
https://bugreports.qt.io/browse/QTBUG-32100

This bug is the actual reason for the compilation failing on Qt5+clang. This is not a problem on Debian (stable and wheezy-backports both have 5.3.2), but it is on Ubuntu precise, where travis' containers run on.

So fixing this means backporting qtbase onto precise.