### PR TITLE
Debian: Add pkgconfig to dependencies

### DIFF
--- a/_travis/install_dependencies
+++ b/_travis/install_dependencies
@@ -19,7 +19,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
 		echo "Using mk-build-deps to resolve package depencencies"
 		sudo mk-build-deps --install --remove
 	else
-		DEPS="libboost-program-options-dev"
+		DEPS="libboost-program-options-dev pkg-config"
 		if [ "$CMAKE_PARAMETERS" = "-DUseQtFive=ON" ] ; then
 			echo "Adding dannyedel ppa"
 			sudo add-apt-repository ppa:dannyedel/libpoppler-qt5-backports -y

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,13 @@ Source: dspdfviewer
 Section: text
 Priority: extra
 Maintainer: Danny Edel <mail@danny-edel.de>
-Build-Depends: g++ (>= 4:4.6),
- debhelper (>= 7.3.0), cmake,
- libpoppler-qt4-dev,
- libboost-program-options-dev,
- lsb-release
-# Note that these dependencies are quite outdated
-# so that the same debian/ directory still compiles
-# on wheezy or precise.
+Build-Depends: cmake,
+               debhelper (>= 7.3.0),
+               g++ (>= 4:4.6),
+               libboost-program-options-dev,
+               libpoppler-qt4-dev,
+               lsb-release,
+               pkg-config
 Standards-Version: 3.9.3
 Vcs-Git: git://github.com/dannyedel/dspdfviewer.git
 Vcs-Browser: https://github.com/dannyedel/dspdfviewer
@@ -17,7 +16,7 @@ Homepage: http://dspdfviewer.danny-edel.de
 
 Package: dspdfviewer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Suggests: latex-beamer
 Description: Dual-Screen PDF Viewer for LaTeX-beamer
  This is a specialized PDF Viewing application custom-made for

--- a/debian/copyright
+++ b/debian/copyright
@@ -23,4 +23,3 @@ License: GPL-2+
  On Debian systems, the full text of the GNU General Public
  License version 2 can be found in the file
  `/usr/share/common-licenses/GPL-2'.
-


### PR DESCRIPTION
Since db1955e3ac00a29461b24d7f59a5ea6be0d82f59 CMakeList uses CMake's pkg-config module to find poppler includes and libraries.

pkg-config was not added to d/control, but since pkg-config was installed on travis, that error got unnoticed.