### PR TITLE
Fix Clang warnings in the source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,9 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	# Disable warnings irrelevant to the project:
 	#   c++98 compatibility warnings
 	add_definitions(-Wno-c++98-compat -Wno-c++98-compat-pedantic)
+	#   FIXME: Weak vtables
+	#   Currently this warning triggers in exception classes
+	add_definitions(-Wno-error=weak-vtables)
 	#   padding
 	add_definitions(-Wno-padded)
 	#   in release mode: Unrechable code / Macro expansion (these stem from QDEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ list(APPEND LIST_INCLUDE_DIRS ${POPPLER_INCLUDE_DIRS})
 list(APPEND LIST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
 list(APPEND LIST_LIBRARIES ${Boost_LIBRARIES})
 
+# include current binary dir, for ui_pdfviewerwindow.h and the .moc files
+# Treat this like system headers because it's generated code
+list(APPEND LIST_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
+
 # Use c++11 support.
 # found on
 # http://stackoverflow.com/questions/10984442/how-to-detect-c11-support-of-a-compiler-with-cmake
@@ -174,7 +178,6 @@ endif()
 
 set(dspdfviewer_SRCS adjustedlink.cpp hyperlinkarea.cpp pdfpagereference.cpp pdfdocumentreference.cpp runtimeconfiguration.cpp renderutils.cpp renderthread.cpp renderingidentifier.cpp pagepart.cpp renderedpage.cpp pdfrenderfactory.cpp pdfviewerwindow.cpp dspdfviewer.cpp windowrole.cpp main.cpp)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_executable(dspdfviewer ${dspdfviewer_SRCS} ${dspdfviewer_UIS_H})
 target_link_libraries(dspdfviewer ${LIST_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	# Turn on a lot of warnings, hopefully helping with code quality.
 	add_definitions(-Weverything)
 	# FIXME: Re-activate -Werror once these are worked out of the source
-	# add_definitions(-Werror)
+	add_definitions(-Werror)
 
 	# Disable warnings irrelevant to the project:
 	#   c++98 compatibility warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,16 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	add_definitions(-Weverything)
 	# FIXME: Re-activate -Werror once these are worked out of the source
 	# add_definitions(-Werror)
-	# Disable c++98 compatibility warnings
+
+	# Disable warnings irrelevant to the project:
+	#   c++98 compatibility warnings
 	add_definitions(-Wno-c++98-compat -Wno-c++98-compat-pedantic)
+	#   padding
+	add_definitions(-Wno-padded)
+	#   in release mode: Unrechable code / Macro expansion (these stem from QDEBUG)
+	if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug" )
+		add_definitions(-Wno-unreachable-code -Wno-unreachable-code -Wno-disabled-macro-expansion)
+	endif()
 else()
 	message(WARNING "Compiling with a Non-GNU compiler. A lot less warnings will be output, so more coding errors might go undetected.")
 endif()

--- a/adjustedlink.cpp
+++ b/adjustedlink.cpp
@@ -21,6 +21,8 @@
 #include "adjustedlink.h"
 
 #include <stdexcept>
+#include <boost/numeric/conversion/cast.hpp>
+using boost::numeric_cast;
 
 QSharedPointer< Poppler::Link > AdjustedLink::link() const
 {
@@ -81,7 +83,12 @@ AdjustedLink::OutsidePage::OutsidePage(): runtime_error("This link is not inside
 
 uint AdjustedLink::targetPageNumber() const
 {
-  return lgt().destination().pageNumber() -1;
+	/* Although page numbers in a PDF are non-negative, poppler's pageNumber
+	 * is a signed integer.
+	 *
+	 * numeric_cast checks that the number actually *is* non-negative.
+	 */
+  return numeric_cast<unsigned>(lgt().destination().pageNumber()) -1u;
 }
 
 

--- a/debug.h
+++ b/debug.h
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 
-#if QT_NO_DEBUG_OUTPUT
+#ifdef QT_NO_DEBUG_OUTPUT
 
 /* Qt is defined to squelch debug output. Simply forward to
  * qDebug()'s definition.

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -33,6 +33,9 @@
 
 #include "debug.h"
 #include <stdexcept>
+#include <boost/numeric/conversion/cast.hpp>
+
+using boost::numeric_cast;
 
 DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
 	runtimeConfiguration(r),
@@ -239,17 +242,8 @@ PdfRenderFactory* DSPDFViewer::theFactory()
 
 unsigned int DSPDFViewer::numberOfPages() const {
   int pages = renderFactory.numberOfPages();
-	if ( pages < 0 )
-	{
-		/* What the... ?!
-		 *
-		 * I return zero, so that any kind of loop that counts "for
-		 * all pages" will terminate immediately.
-		 */
-		return 0;
-	}
-	/* numPages is non-negative and therefore safe to use. */
-	return pages;
+  // Numeric cast includes error handling.
+  return numeric_cast<uint>(pages);
 }
 
 void DSPDFViewer::goToStartAndResetClocks()

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -232,8 +232,6 @@ void DSPDFViewer::exit()
   secondaryWindow.close();
 }
 
-const QSize DSPDFViewer::thumbnailSize = QSize(200, 100);
-
 PdfRenderFactory* DSPDFViewer::theFactory()
 {
   return &renderFactory;

--- a/dspdfviewer.h
+++ b/dspdfviewer.h
@@ -55,9 +55,6 @@ private:
 
 
 
-public:
-  static const QSize thumbnailSize;
-
 private:
   QImage renderForTarget( QSharedPointer<Poppler::Page> page, QSize targetSize, bool onlyHalf, bool rightHalf=false);
 

--- a/hyperlinkarea.cpp
+++ b/hyperlinkarea.cpp
@@ -21,7 +21,10 @@
 #include "hyperlinkarea.h"
 #include <stdexcept>
 #include <cmath>
+#include <boost/math/special_functions/round.hpp>
 #include "debug.h"
+
+using boost::math::iround;
 
 HyperlinkArea::HyperlinkArea(QLabel* imageLabel, const AdjustedLink& link): QLabel(), targetPage(link.targetPageNumber())
 {
@@ -34,11 +37,11 @@ HyperlinkArea::HyperlinkArea(QLabel* imageLabel, const AdjustedLink& link): QLab
   
   QRectF sizeWithinImageLabel = link.linkArea();
   
-  mySize.setTop(sizeWithinImageLabel.top() * pixmap->height());
-  mySize.setLeft(sizeWithinImageLabel.left() * pixmap->width());
+  mySize.setTop( iround(sizeWithinImageLabel.top() * pixmap->height()) );
+  mySize.setLeft( iround(sizeWithinImageLabel.left() * pixmap->width()) );
   
-  mySize.setHeight(std::abs(sizeWithinImageLabel.height() * pixmap->height()));
-  mySize.setWidth(sizeWithinImageLabel.width() * pixmap->width()); 
+  mySize.setHeight(std::abs( iround(sizeWithinImageLabel.height() * pixmap->height())) );
+  mySize.setWidth( iround(sizeWithinImageLabel.width() * pixmap->width()) ); 
   
   setParent(imageLabel);
   setGeometry(mySize);

--- a/pdfdocumentreference.h
+++ b/pdfdocumentreference.h
@@ -56,6 +56,12 @@ public:
    */
   PDFDocumentReference& operator = (const PDFDocumentReference& rhs);
 
+  /** Since we define a custom copy-assignment, tell the compiler
+   * explicitly that the standard copy-construct is all right
+   */
+  PDFDocumentReference(const PDFDocumentReference& ) =default;
+  PDFDocumentReference(PDFDocumentReference&&) =default;
+
   /** Compares the references. Exact behaviour depends on the cache option:
    * If we are memory-caching, this compares the ByteArrays (i.e. checks for
    * identical files).

--- a/pdfpagereference.cpp
+++ b/pdfpagereference.cpp
@@ -1,7 +1,11 @@
 #include "pdfpagereference.h"
 
+#include <boost/numeric/conversion/cast.hpp>
+
+using boost::numeric_cast;
+
 PDFPageReference::PDFPageReference(const PDFDocumentReference& documentReference, const unsigned int& pageNumber):
   document( documentReference.popplerDocument() ),
-  page( document->page(pageNumber) )
+  page( document->page( numeric_cast<int>(pageNumber) ) )
 {
 }

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -155,7 +155,7 @@ void PdfRenderFactory::fileOnDiskChanged(const QString& filename)
     }
 
     emit pdfFileRereadSuccesfully();
-  } catch( std::runtime_error& e) {
+  } catch( std::runtime_error& ) {
     DEBUGOUT << "Unable to read the new reference. keeping the old one.";
     emit pdfFileRereadFailed();
   }

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -27,9 +27,6 @@
 #include <stdexcept>
 #include "debug.h"
 
-
-static const QSize ThumbnailSize(200,100);
-
 void PdfRenderFactory::pageThreadFinishedRendering(QSharedPointer<RenderedPage> renderedPage)
 {
   {

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -29,6 +29,9 @@
 #include <QMessageBox>
 #include "sconnect.h"
 #include <cstdlib>
+#include <boost/numeric/conversion/cast.hpp>
+
+using boost::numeric_cast;
 
 void PDFViewerWindow::setMonitor(const unsigned int monitor)
 {
@@ -58,8 +61,8 @@ PDFViewerWindow::PDFViewerWindow(unsigned int monitor, PagePart myPart, bool sho
     return;
   setupUi(this);
   unsigned mainImageHeight=100-r.bottomPaneHeight();
-  verticalLayout->setStretch(0, mainImageHeight);
-  verticalLayout->setStretch(1, r.bottomPaneHeight());
+  verticalLayout->setStretch(0, numeric_cast<int>(mainImageHeight) );
+  verticalLayout->setStretch(1, numeric_cast<int>(r.bottomPaneHeight()) );
   setWindowRole(to_QString(wr));
   setWindowTitle(QString("DS PDF Viewer - %1").arg(windowRole()).replace('_', ' ') );
   if ( !showInformationLine || ! r.showPresenterArea()) {
@@ -89,7 +92,7 @@ void PDFViewerWindow::reposition()
     return;
   this->setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
   this->showNormal();
-  QRect rect = QApplication::desktop()->screenGeometry(getMonitor());
+  QRect rect = QApplication::desktop()->screenGeometry( numeric_cast<int>(getMonitor()) );
   move(rect.topLeft());
   resize( rect.size() );
   this->showFullScreen();
@@ -303,7 +306,7 @@ void PDFViewerWindow::renderedPageIncoming(QSharedPointer< RenderedPage > render
   }
 }
 
-void PDFViewerWindow::showLoadingScreen(int pageNumberToWaitFor)
+void PDFViewerWindow::showLoadingScreen(uint pageNumberToWaitFor)
 {
   if ( !m_enabled )
     return;
@@ -425,11 +428,11 @@ void PDFViewerWindow::changePageNumberDialog()
 	/* Input field caption */
 	QString(tr("Jump to page number (%1-%2):")).arg(displayMinNumber).arg(displayMaxNumber),
 	/* Starting number. */
-	displayCurNumber,
+	numeric_cast<int>(displayCurNumber),
 	/* minimum value */
-	displayMinNumber,
+	numeric_cast<int>(displayMinNumber),
 	/* maximum value */
-	displayMaxNumber,
+	numeric_cast<int>(displayMaxNumber),
 	/* Step */
 	1,
 	/* Did the user accept? */
@@ -437,7 +440,7 @@ void PDFViewerWindow::changePageNumberDialog()
   targetPageNumber-=1; // Convert back to zero-based numbering scheme
   if ( ok )
   {
-    emit pageRequested(targetPageNumber);
+    emit pageRequested(numeric_cast<uint>(targetPageNumber));
   }
 }
 

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -221,17 +221,12 @@ QSize PDFViewerWindow::getPreviewImageSize()
 void PDFViewerWindow::mousePressEvent(QMouseEvent* e)
 {
     // QWidget::mousePressEvent(e);
-    switch (e->button()) {
-      case Qt::LeftButton:
-	emit nextPageRequested();
-	break;
-      case Qt::RightButton:
-	emit previousPageRequested();
-	break;
-      default: /* any other button */
-	/* do nothing */
-	break;
-    }
+	if ( e->button() == Qt::LeftButton ) {
+		emit nextPageRequested();
+	} else if ( e->button() == Qt::RightButton ) {
+		emit previousPageRequested();
+	}
+	// Ignore other buttons.
 }
 
 void PDFViewerWindow::hideInformationLine()

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -47,14 +47,14 @@ unsigned int PDFViewerWindow::getMonitor() const
   return m_monitor;
 }
 
-PDFViewerWindow::PDFViewerWindow(unsigned int monitor, PagePart myPart, bool showInformationLine, const RuntimeConfiguration& r, const WindowRole& wr, bool enabled):
+PDFViewerWindow::PDFViewerWindow(unsigned int monitor, PagePart pagePart, bool showInformationLine, const RuntimeConfiguration& r, const WindowRole& wr, bool enabled):
   QWidget(),
   m_enabled(enabled),
   m_monitor(monitor),
   blank(false),
   minimumPageNumber(0),
   maximumPageNumber(65535),
-  myPart(myPart),
+  myPart(pagePart),
   runtimeConfiguration(r)
 {
   if ( ! enabled )
@@ -444,18 +444,18 @@ void PDFViewerWindow::changePageNumberDialog()
   }
 }
 
-void PDFViewerWindow::setPageNumberLimits(uint minimumPageNumber, uint maximumPageNumber)
+void PDFViewerWindow::setPageNumberLimits(uint minPageNumber, uint maxPageNumber)
 {
-  this->minimumPageNumber = minimumPageNumber;
-  this->maximumPageNumber = maximumPageNumber;
+  this->minimumPageNumber = minPageNumber;
+  this->maximumPageNumber = maxPageNumber;
 }
 
-void PDFViewerWindow::setBlank(const bool blank)
+void PDFViewerWindow::setBlank(const bool newBlank)
 {
-  if ( this->blank == blank)
+  if ( this->blank == newBlank)
     return;
   /* State changes. request re-render */
-  this->blank = blank;
+  this->blank = newBlank;
   DEBUGOUT << "Changing blank state to" << blank;
   if ( blank ) {
     imageLabel->clear();
@@ -476,7 +476,7 @@ void PDFViewerWindow::setMyPagePart(const PagePart& newPagePart)
 
 void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
 {
-  QList< HyperlinkArea* > linkAreas;
+  QList< HyperlinkArea* > newLinkAreas;
   for( AdjustedLink const & link: links ) {
     const QRectF& rect = link.linkArea();
     if ( rect.isNull() ) {
@@ -493,7 +493,7 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
       }
       HyperlinkArea* linkArea = new HyperlinkArea(imageLabel, link);
       sconnect( linkArea, SIGNAL(gotoPageRequested(uint)), this, SLOT(linkClicked(uint)) );
-      linkAreas.append(linkArea);
+      newLinkAreas.append(linkArea);
     }
     else {
       qWarning() << "Types other than Goto are not supported yet.";
@@ -504,7 +504,7 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
   for( HyperlinkArea* hla: this->linkAreas)
     hla->deleteLater();
   // Add the new list
-  this->linkAreas = linkAreas;
+  this->linkAreas = newLinkAreas;
 }
 
 void PDFViewerWindow::linkClicked(uint targetNumber)

--- a/pdfviewerwindow.h
+++ b/pdfviewerwindow.h
@@ -76,7 +76,6 @@ private:
 public:
   /** Standard constructor
    * @param monitor monitor to start on (usually 0 for primary)
-   * @param dspdfviewer Pointer to the application (to handle next/prev commands)
    */
     explicit PDFViewerWindow(unsigned int monitor, PagePart myPart, bool showInformationLine, const RuntimeConfiguration& r, const WindowRole& windowRole, bool enabled=true);
 

--- a/pdfviewerwindow.h
+++ b/pdfviewerwindow.h
@@ -107,7 +107,7 @@ public:
 
     bool isBlank() const;
 
-    void showLoadingScreen(int pageNumberToWaitFor);
+    void showLoadingScreen(uint pageNumberToWaitFor);
 
 public slots:
   void renderedPageIncoming( QSharedPointer<RenderedPage> renderedPage);

--- a/renderingidentifier.cpp
+++ b/renderingidentifier.cpp
@@ -46,7 +46,7 @@ RenderingIdentifier::operator QString() const
   return s.arg(pageNumber()).arg(partId).arg(requestedPageSize().width()).arg(requestedPageSize().height());
 }
 
-int RenderingIdentifier::pageNumber() const
+unsigned RenderingIdentifier::pageNumber() const
 {
   return thePageNumber;
 }
@@ -61,7 +61,7 @@ QSize RenderingIdentifier::requestedPageSize() const
   return theRequestedPageSize;
 }
 
-RenderingIdentifier::RenderingIdentifier(int pagenum, PagePart pagepart, QSize pagesize):
+RenderingIdentifier::RenderingIdentifier(unsigned pagenum, PagePart pagepart, QSize pagesize):
   thePageNumber(pagenum), thePagePart(pagepart), theRequestedPageSize(pagesize)
 {
 

--- a/renderingidentifier.h
+++ b/renderingidentifier.h
@@ -28,7 +28,7 @@
 class RenderingIdentifier
 {
 private:
-  int thePageNumber;
+  unsigned thePageNumber;
   PagePart thePagePart;
   QSize theRequestedPageSize;
 
@@ -40,7 +40,7 @@ public:
    */
   quint64 theVersion;
 
-  RenderingIdentifier(int pagenum, PagePart pagepart, QSize requestedPageSize);
+  RenderingIdentifier(unsigned pagenum, PagePart pagepart, QSize requestedPageSize);
   unsigned pageNumber() const;
   PagePart pagePart() const;
   QSize requestedPageSize() const;

--- a/renderingidentifier.h
+++ b/renderingidentifier.h
@@ -41,7 +41,7 @@ public:
   quint64 theVersion;
 
   RenderingIdentifier(int pagenum, PagePart pagepart, QSize requestedPageSize);
-  int pageNumber() const;
+  unsigned pageNumber() const;
   PagePart pagePart() const;
   QSize requestedPageSize() const;
 

--- a/renderthread.cpp
+++ b/renderthread.cpp
@@ -51,7 +51,7 @@ void RenderThread::run()
     try{
       AdjustedLink al(renderMe, ptrLink);
       links.append(al);
-    } catch( AdjustedLink::OutsidePage & e) {
+    } catch( AdjustedLink::OutsidePage &) {
       // no-op
     }
   }

--- a/renderutils.cpp
+++ b/renderutils.cpp
@@ -23,6 +23,10 @@
 #include "debug.h"
 #include <stdexcept>
 
+#include <boost/math/special_functions/round.hpp>
+
+using boost::math::iround;
+
 QImage RenderUtils::renderPagePart(QSharedPointer< Poppler::Page > page, QSize targetSize, PagePart whichPart)
 {
   if ( ! page )
@@ -51,12 +55,12 @@ QImage RenderUtils::renderPagePart(QSharedPointer< Poppler::Page > page, QSize t
 
   /* Calculate Page Size in pixels */
 
-  QSize fullSizePixels( dpi * fullsize.width() / 72.0,
-			dpi * fullsize.height() / 72.0);
+  QSize fullSizePixels( iround(dpi * fullsize.width() / 72.0),
+			iround(dpi * fullsize.height() / 72.0) );
 
   /* Calculate rendered image size */
-  QSize imageSizePixels(dpi * pagesize.width() / 72.0,
-		  dpi * pagesize.height() / 72.0 );
+  QSize imageSizePixels( iround(dpi * pagesize.width() / 72.0),
+		  iround( dpi * pagesize.height() / 72.0 ) );
 
   /* Calculate x-offset */
   int x = 0;


### PR DESCRIPTION
Compiling with clangs `-Weverything` exposed a lot more little things that may one day become a problem.

Mostly this is unmarked signed<->unsigned operations or float<->int, but clang also warns about shadowing (using a function parameter that hides an object property).

Generally use boost's numeric_cast for signed<->unsigned conversions (this will range check) and use boost's iround for float->int rounding.