### PR TITLE
Refactor the Help Dialog box into its own .ui file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND TRANSLATIONFILES
 )
 list(APPEND UIFILES
 	pdfviewerwindow.ui
+	keybindings.ui
 )
 list(APPEND dspdfviewer_SRCS
 	adjustedlink.cpp
@@ -94,7 +95,7 @@ else()
 
 	list(APPEND LIST_INCLUDE_DIRS ${QT_INCLUDES})
 	list(APPEND LIST_LIBRARIES Qt4::QtGui)
-	qt4_wrap_ui(dspdfviewer_UIS_H pdfviewerwindow.ui)
+	qt4_wrap_ui(dspdfviewer_UIS_H ${UIFILES})
 	if( UpdateTranslations )
 		qt4_create_translation(TRANSLATIONS ${dspdfviewer_SRCS} ${UIFILES} ${TRANSLATIONFILES})
 	else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ endif()
 add_definitions(-DQT_NO_CAST_FROM_ASCII)
 
 
-add_library(libdspdfviewer ${dspdfviewer_SRCS} ${dspdfviewer_UIS_H})
+add_library(libdspdfviewer ${dspdfviewer_SRCS} ${dspdfviewer_UIS_H} ${TRANSLATIONS})
 set_target_properties(libdspdfviewer PROPERTIES OUTPUT_NAME dspdfviewer)
 target_link_libraries(libdspdfviewer ${LIST_LIBRARIES})
 

--- a/keybindings.ui
+++ b/keybindings.ui
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>KeybindingsDialog</class>
+ <widget class="QDialog" name="KeybindingsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>554</width>
+    <height>224</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Keybindings</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Key</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Action</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Next slide</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>N or Left/Down arrow</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>P or Right/Down arrow</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Blank/Unblank audience screen</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="label_14">
+       <property name="text">
+        <string>Quit</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Previous slide</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Go to specific slide</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLabel" name="label_18">
+       <property name="text">
+        <string>Toggle between notes and slides on the secondary screen</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QLabel" name="label_20">
+       <property name="text">
+        <string>Toggle between displaying both notes and slides on the secondary screen or only notes</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLabel" name="label_16">
+       <property name="text">
+        <string>Switch primary and secondary screens</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Go to first page and reset counters</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QLabel" name="label_22">
+       <property name="text">
+        <string>Show this help box</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>B or .</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>G</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_11">
+       <property name="text">
+        <string>H or Home</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_13">
+       <property name="text">
+        <string>Q or Esc</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_15">
+       <property name="text">
+        <string>S or F12</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_17">
+       <property name="text">
+        <string>T</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_19">
+       <property name="text">
+        <string>D</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_21">
+       <property name="text">
+        <string>? or F1</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>pushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>KeybindingsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>200</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>398</x>
+     <y>201</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -30,6 +30,7 @@
 #include "sconnect.h"
 #include <cstdlib>
 #include <boost/numeric/conversion/cast.hpp>
+#include "ui_keybindings.h"
 
 using boost::numeric_cast;
 
@@ -407,26 +408,10 @@ void PDFViewerWindow::updateWallClock(const QTime& wallClock)
 
 void PDFViewerWindow::keybindingsPopup()
 {
-  QMessageBox *popup   = new QMessageBox();
-  QString msg = tr(
-  "<table>\n"
-  "<tr><th width=200 align=left>Key</th><th width=400 align=left>Action</th></tr>\n"
-  /* I skip some navigation bindings (they have to many alternatives) */
-  "<tr><td>N or Left/Down arrow</td><td>Next slide</td></tr>\n"
-  "<tr><td>P or Right/Up arrow</td><td>Previous slide</td></tr>\n"
-  "<tr><td>B or .</td><td>Blank/Unblank audience screen</td></tr>\n"
-  "<tr><td>G</td><td>Go to specific slide</td></tr>\n"
-  "<tr><td>H or Home</td><td>Go to first page and reset counters</td></tr>\n"
-  "<tr><td>Q or Esc</td><td>Quit</td></tr>\n"
-  "<tr><td>S or F12</td><td>Switch primary and secondary screens</td></tr>\n"
-  "<tr><td>T</td><td>Toggle between notes and slides in the secondary screen</td></tr>\n"
-  "<tr><td>D</td><td>Toggle between displaying both notes and slides in the secondary screen or only notes</td></tr>\n"
-  "<tr><td>? or F1</td><td>Show this help box</td></tr>\n"
-  "</table>"
-  );
-  popup->setWindowTitle(tr("Keybindings"));
-  popup->setText(msg);
-  popup->show();
+	Ui::KeybindingsDialog ui;
+	QDialog popup;
+	ui.setupUi(&popup);
+	popup.exec();
 }
 
 void PDFViewerWindow::changePageNumberDialog()

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -408,9 +408,9 @@ void PDFViewerWindow::updateWallClock(const QTime& wallClock)
 
 void PDFViewerWindow::keybindingsPopup()
 {
-	Ui::KeybindingsDialog ui;
+	Ui::KeybindingsDialog keybindUi;
 	QDialog popup;
-	ui.setupUi(&popup);
+	keybindUi.setupUi(&popup);
 	popup.exec();
 }
 

--- a/translations/dspdfviewer_de.ts
+++ b/translations/dspdfviewer_de.ts
@@ -81,14 +81,137 @@
     </message>
 </context>
 <context>
+    <name>KeybindingsDialog</name>
+    <message>
+        <location filename="../keybindings.ui" line="20"/>
+        <source>Keybindings</source>
+        <translation type="unfinished">Tastenkombinationen</translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="38"/>
+        <source>Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="52"/>
+        <source>Action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="59"/>
+        <source>Next slide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="66"/>
+        <source>N or Left/Down arrow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="73"/>
+        <source>P or Right/Down arrow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="80"/>
+        <source>Blank/Unblank audience screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="87"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="94"/>
+        <source>Previous slide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="101"/>
+        <source>Go to specific slide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="108"/>
+        <source>Toggle between notes and slides on the secondary screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="115"/>
+        <source>Toggle between displaying both notes and slides on the secondary screen or only notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="122"/>
+        <source>Switch primary and secondary screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="129"/>
+        <source>Go to first page and reset counters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="136"/>
+        <source>Show this help box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="143"/>
+        <source>B or .</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="150"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="157"/>
+        <source>H or Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="164"/>
+        <source>Q or Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="171"/>
+        <source>S or F12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="178"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="185"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="192"/>
+        <source>? or F1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../keybindings.ui" line="216"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PDFViewerWindow</name>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="339"/>
+        <location filename="../pdfviewerwindow.cpp" line="340"/>
         <source>Loading page number %1</source>
         <translation>Lade Seite Nummer %1</translation>
     </message>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="384"/>
+        <location filename="../pdfviewerwindow.cpp" line="385"/>
         <source>HH:mm:ss</source>
         <comment>This is used by QTime::toString. See its documentation before changing this.</comment>
         <translation>HH:mm:ss</translation>
@@ -100,45 +223,27 @@
 %1</translation>
     </message>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="76"/>
+        <location filename="../pdfviewerwindow.cpp" line="77"/>
         <source>DS PDF Viewer - Audience Window</source>
         <extracomment>User visible Window Title Line</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="78"/>
+        <location filename="../pdfviewerwindow.cpp" line="79"/>
         <source>DS PDF Viewer - Secondary Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="411"/>
-        <source>&lt;table&gt;
-&lt;tr&gt;&lt;th width=200 align=left&gt;Key&lt;/th&gt;&lt;th width=400 align=left&gt;Action&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;N or Left/Down arrow&lt;/td&gt;&lt;td&gt;Next slide&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;P or Right/Up arrow&lt;/td&gt;&lt;td&gt;Previous slide&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;B or .&lt;/td&gt;&lt;td&gt;Blank/Unblank audience screen&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;G&lt;/td&gt;&lt;td&gt;Go to specific slide&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;H or Home&lt;/td&gt;&lt;td&gt;Go to first page and reset counters&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;Q or Esc&lt;/td&gt;&lt;td&gt;Quit&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;S or F12&lt;/td&gt;&lt;td&gt;Switch primary and secondary screens&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;T&lt;/td&gt;&lt;td&gt;Toggle between notes and slides in the secondary screen&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;D&lt;/td&gt;&lt;td&gt;Toggle between displaying both notes and slides in the secondary screen or only notes&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;? or F1&lt;/td&gt;&lt;td&gt;Show this help box&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</source>
-        <translation type="unfinished"></translation>
+        <source>Keybindings</source>
+        <translation type="obsolete">Tastenkombinationen</translation>
     </message>
     <message>
         <location filename="../pdfviewerwindow.cpp" line="427"/>
-        <source>Keybindings</source>
-        <translation>Tastenkombinationen</translation>
-    </message>
-    <message>
-        <location filename="../pdfviewerwindow.cpp" line="442"/>
         <source>Select page</source>
         <translation>Seite auswählen</translation>
     </message>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="444"/>
+        <location filename="../pdfviewerwindow.cpp" line="429"/>
         <source>Jump to page number (%1-%2):</source>
         <translation>Springe zu Seite Nummer (%1-%2):</translation>
     </message>
@@ -153,7 +258,7 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../pdfviewerwindow.cpp" line="395"/>
+        <location filename="../pdfviewerwindow.cpp" line="396"/>
         <source>Form</source>
         <comment>Total
 %1</comment>


### PR DESCRIPTION
Currently it's a HTML-formatted label. While there's nothing wrong with that, it will probably confuse translators after #40 is merged (not every translator will type correctly formatted html).

If its refactored into its own .ui file, it will have its own class which should provide enough context to translators.