### PR TITLE
pdfviewerwindow: change tr() to translate()

### DIFF
--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -393,7 +393,7 @@ QString PDFViewerWindow::timeToString(int milliseconds) const
 
 void PDFViewerWindow::updatePresentationClock(const QTime& presentationClock)
 {
-  ui.presentationClock->setText( QCoreApplication::tr("Form", "Total\n%1").arg(timeToString(presentationClock)));
+  ui.presentationClock->setText( QCoreApplication::translate("Form", "Total\n%1").arg(timeToString(presentationClock)));
 }
 
 void PDFViewerWindow::updateSlideClock(const QTime& slideClock)


### PR DESCRIPTION
This fixes the display of the presentation clock.