### PR TITLE
Use QWindow and setScreen only on WIN32

### DIFF
--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -24,7 +24,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
-#ifdef POPPLER_QT5
+#if defined(POPPLER_QT5) && defined(_WIN32)
 #include <QWindow>
 #endif
 #include "debug.h"
@@ -108,7 +108,7 @@ void PDFViewerWindow::reposition()
     return;
   this->setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
   this->showNormal();
-#ifdef POPPLER_QT5
+#if defined(POPPLER_QT5) && defined(_WIN32)
   this->windowHandle()->setScreen(QApplication::screens()[numeric_cast<int>(getMonitor())]);
   this->showFullScreen();
 #else


### PR DESCRIPTION
Fixes #90.

@projekter, could you verify that under Windows, this branch compiles and works as intended (Windows spawning on correct screens)?  Since it does not work anymore under my Linux box, I've added `&& defined(_WIN32)` to the code, but I can't check if it works.