### PR TITLE
travis: only build master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: cpp
 sudo: required
+# Only build master branch on push, other branches will get built when
+# they are turned into pull-requests
+branches:
+    only:
+        - master
 matrix:
     # This marks the build as failed as soon as something goes wrong
     fast_finish: true


### PR DESCRIPTION
This should avoid the problem of pull-requests getting build twice (once
as push, and once as pull-request)