### PR TITLE
Load translation from resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,9 @@ option(CodeCoverage "Add coverage analysis code to the program. Will slow it dow
 
 include(cmake/filelists.cmake)
 include(cmake/external_libraries.cmake)
+include(cmake/qrc_embedding.cmake)
 include(cmake/compilers.cmake)
 include(cmake/version_number.cmake)
-include(cmake/qrc_embedding.cmake)
 
 
 if( I3WORKAROUND_SHELLCODE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include(cmake/filelists.cmake)
 include(cmake/external_libraries.cmake)
 include(cmake/compilers.cmake)
 include(cmake/version_number.cmake)
+include(cmake/qrc_embedding.cmake)
 
 
 if( I3WORKAROUND_SHELLCODE )
@@ -54,7 +55,7 @@ endif()
 target_link_libraries(libdspdfviewer ${LIST_LIBRARIES})
 
 ### And link it together with main.cpp to produce an executable
-add_executable(dspdfviewer main)
+add_executable(dspdfviewer main ${EMBEDDED_QRC})
 target_link_libraries(dspdfviewer libdspdfviewer)
 
 ### ... and link it with the tests to produce a testing executable.

--- a/_travis/install_dependencies
+++ b/_travis/install_dependencies
@@ -11,7 +11,7 @@ install_via_aptget() {
 
 if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
 	# Update list of available packages in any case
-	DEPS="libboost-program-options-dev libboost-test-dev pkg-config"
+	DEPS="libboost-program-options-dev libboost-test-dev pkg-config xvfb"
 	if [ "$QT_VERSION" -eq 5 ] ; then
 		DEPS="${DEPS} libpoppler-qt5-dev qtbase5-dev qttools5-dev qttools5-dev-tools"
 	else

--- a/cmake/compiler_clang.cmake
+++ b/cmake/compiler_clang.cmake
@@ -34,7 +34,7 @@ add_definitions(-Wno-error=undefined-reinterpret-cast)
 
 # qrc system generates code that triggers a lot of the
 # clang warnings.
-set_source_files_properties(dspdfviewer.qrc.cxx
+set_source_files_properties( ${EMBEDDED_QRC}
 	PROPERTIES COMPILE_FLAGS "-Wno-error")
 
 # Include directories with -isystem to supress warnings

--- a/cmake/compiler_clang.cmake
+++ b/cmake/compiler_clang.cmake
@@ -29,7 +29,13 @@ endif()
 # about undefined behaviours.
 
 # So don't set Werror for it.
+# TODO: Set this only for the automoc files
 add_definitions(-Wno-error=undefined-reinterpret-cast)
+
+# qrc system generates code that triggers a lot of the
+# clang warnings.
+set_source_files_properties(dspdfviewer.qrc.cxx
+	PROPERTIES COMPILE_FLAGS "-Wno-error")
 
 # Include directories with -isystem to supress warnings
 foreach(lib IN LISTS LIST_INCLUDE_DIRS)

--- a/cmake/qrc_embedding.cmake
+++ b/cmake/qrc_embedding.cmake
@@ -1,0 +1,34 @@
+# Copy all the filex in QRCFILES into the binary dir,
+# and execute qrc (Qt Resource Compiler) on them.
+
+foreach(qrc IN LISTS QRCFILES)
+
+	add_custom_command(
+		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${qrc}
+		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${qrc}
+		COMMAND cmake -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${qrc} ${CMAKE_CURRENT_BINARY_DIR}/${qrc}
+	)
+
+	set(TMP_OUTFILENAME "${CMAKE_CURRENT_BINARY_DIR}/${qrc}.cxx")
+
+	if(UseQtFive)
+		set(RCCCOMPILER ${Qt5Core_RCC_EXECUTABLE})
+	else()
+		set(RCCCOMPILER ${QT_RCC_EXECUTABLE})
+	endif()
+
+
+	add_custom_command(
+		OUTPUT ${TMP_OUTFILENAME}
+		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${qrc}
+		COMMAND ${RCCCOMPILER} -o ${TMP_OUTFILENAME} ${CMAKE_CURRENT_BINARY_DIR}/${qrc}
+	)
+
+	unset(RCCCOMPILER)
+
+	list(APPEND EMBEDDED_QRC
+		${TMP_OUTFILENAME}
+	)
+
+	unset(TMP_OUTFILENAME)
+endforeach()

--- a/dspdfviewer.qrc
+++ b/dspdfviewer.qrc
@@ -1,5 +1,5 @@
 <!DOCTYPE RCC><RCC version="1.0">
-<qresource prefix="/translations">
-    <file>dspdfviewer_de.qm</file>
+<qresource prefix="/translations" lang="de">
+    <file alias="dspdfviewer.qm">dspdfviewer_de.qm</file>
 </qresource>
 </RCC>

--- a/main.cpp
+++ b/main.cpp
@@ -76,8 +76,8 @@ int main(int argc, char** argv)
 	}
 
 	QTranslator appTranslator;
-	DEBUGOUT << "Loading dspdfviewer_ translation for" << localeName;
-	if ( ! appTranslator.load(QString::fromUtf8("dspdfviewer_").append(localeName) ) ) {
+	DEBUGOUT << "Loading dspdfviewer translation for current locale:" << localeName;
+	if ( ! appTranslator.load(QString::fromUtf8(":/translations/dspdfviewer") ) ) {
 		qWarning() << "Failed to load dspdfviewer translation for current locale, falling back to english.";
 	} else {
 		app.installTranslator(&appTranslator);

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -58,7 +58,7 @@ add_test(NAME BoostTestRunner
 # Check that the translations get activated
 
 add_test(NAME EnglishByDefault
-	COMMAND cmake -E env --unset=LANGUAGE --unset=LC_ALL ../dspdfviewer --help
+	COMMAND env --unset=LANGUAGE --unset=LC_ALL ../dspdfviewer --help
 )
 
 set_tests_properties(EnglishByDefault PROPERTIES
@@ -66,7 +66,7 @@ set_tests_properties(EnglishByDefault PROPERTIES
 	)
 
 add_test(NAME GermanWithDeDE
-	COMMAND cmake -E env LANGUAGE=de LC_ALL=de_DE@UTF-8 ../dspdfviewer --help
+	COMMAND env LANGUAGE=de LC_ALL=de_DE@UTF-8 ../dspdfviewer --help
 )
 
 set_tests_properties(GermanWithDeDE PROPERTIES

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -58,7 +58,7 @@ add_test(NAME BoostTestRunner
 # Check that the translations get activated
 
 add_test(NAME EnglishByDefault
-	COMMAND env --unset=LANGUAGE --unset=LC_ALL ../dspdfviewer --help
+	COMMAND env LANGUAGE=C LC_ALL=C.UTF-8 xvfb-run -a ../dspdfviewer --help
 )
 
 set_tests_properties(EnglishByDefault PROPERTIES
@@ -66,7 +66,7 @@ set_tests_properties(EnglishByDefault PROPERTIES
 	)
 
 add_test(NAME GermanWithDeDE
-	COMMAND env LANGUAGE=de LC_ALL=de_DE@UTF-8 ../dspdfviewer --help
+	COMMAND env LANGUAGE=de LC_ALL=de_DE.UTF-8 xvfb-run -a ../dspdfviewer --help
 )
 
 set_tests_properties(GermanWithDeDE PROPERTIES

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -54,3 +54,21 @@ endif()
 add_test(NAME BoostTestRunner
 	COMMAND testrunner --report_level=detailed
 )
+
+# Check that the translations get activated
+
+add_test(NAME EnglishByDefault
+	COMMAND cmake -E env --unset=LANGUAGE --unset=LC_ALL ../dspdfviewer --help
+)
+
+set_tests_properties(EnglishByDefault PROPERTIES
+	PASS_REGULAR_EXPRESSION "Interactive Controls"
+	)
+
+add_test(NAME GermanWithDeDE
+	COMMAND cmake -E env LANGUAGE=de LC_ALL=de_DE@UTF-8 ../dspdfviewer --help
+)
+
+set_tests_properties(GermanWithDeDE PROPERTIES
+	PASS_REGULAR_EXPRESSION "Interaktive Tasten"
+)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -57,8 +57,17 @@ add_test(NAME BoostTestRunner
 
 # Check that the translations get activated
 
+if(APPLE)
+	set(XVFB "")
+elseif(WIN32)
+	set(XFFB "")
+else()
+	set(XVFB "xvfb-run -a")
+endif()
+separate_arguments(XVFB)
+
 add_test(NAME EnglishByDefault
-	COMMAND env LANGUAGE=C LC_ALL=C.UTF-8 xvfb-run -a ../dspdfviewer --help
+	COMMAND env LANGUAGE=C LC_ALL=C.UTF-8 ${XVFB} ../dspdfviewer --help
 )
 
 set_tests_properties(EnglishByDefault PROPERTIES
@@ -66,7 +75,7 @@ set_tests_properties(EnglishByDefault PROPERTIES
 	)
 
 add_test(NAME GermanWithDeDE
-	COMMAND env LANGUAGE=de LC_ALL=de_DE.UTF-8 xvfb-run -a ../dspdfviewer --help
+	COMMAND env LANGUAGE=de LC_ALL=de_DE.UTF-8 ${XVFB} ../dspdfviewer --help
 )
 
 set_tests_properties(GermanWithDeDE PROPERTIES


### PR DESCRIPTION
This loads the translation file from the Qt Resource system by copying
the qrc file into the build tree, and then running rcc (which would
otherwise search for the qm files in the source tree)

Fixes #77.