### PR TITLE
Travis: correctly specify trusty beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
           env: QT_VERSION=4
           compiler: clang
         - os: linux
-          services: docker
+          dist: trusty
           env: QT_VERSION=5
           compiler: gcc
         - os: linux
-          services: docker
+          dist: trusty
           env: QT_VERSION=5
           compiler: clang
         - os: osx


### PR DESCRIPTION
Last month, travis-ci announced[1] trusty beta, adding a "dist" keyword
to select a trusty machine.

[1]: http://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta/