### PR TITLE
Make link-type (static/dynamic) of boost a cmake variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
           dist: trusty
           env: QT_VERSION=5
           compiler: clang
+        - os: linux
+          dist: trusty
+          env: QT_VERSION=5 BOOST_STATIC=1
+          compiler: gcc
         - os: osx
           env: QT_VERSION=4
           compiler: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(UseQtFive "Build with Qt5 and libpoppler-qt5" OFF)
 option(UpdateTranslations "Do you want to update the .ts files (WARNING: running make clean will delete them!)" OFF)
 option(BuildTests "Build unit tests (this requires pdflatex or internet access and DownloadTestPDFs=ON)" ON)
+option(LinkBoostTestDynamic "Link dynamically against the boost::test library" ON)
 option(DownloadTestPDF "Download test PDFs from http://danny-edel.de, rather then building them using latex-beamer" OFF)
 option(CodeCoverage "Add coverage analysis code to the program. Will slow it down. A lot. Only supported on GCC right now." OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(UseQtFive "Build with Qt5 and libpoppler-qt5" OFF)
 option(UpdateTranslations "Do you want to update the .ts files (WARNING: running make clean will delete them!)" OFF)
 option(BuildTests "Build unit tests (this requires pdflatex or internet access and DownloadTestPDFs=ON)" ON)
-option(LinkBoostTestDynamic "Link dynamically against the boost::test library" ON)
+option(BoostStaticLink "Link statically against the boost libraries" OFF)
 option(DownloadTestPDF "Download test PDFs from http://danny-edel.de, rather then building them using latex-beamer" OFF)
 option(CodeCoverage "Add coverage analysis code to the program. Will slow it down. A lot. Only supported on GCC right now." OFF)
 

--- a/_travis/compile
+++ b/_travis/compile
@@ -15,6 +15,11 @@ else
 fi
 
 CMAKE_PARAMETERS="-DDownloadTestPDF=ON"
+
+if [ "$BOOST_STATIC" ] ; then
+	CMAKE_PARAMETERS="$CMAKE_PARAMETERS -DLinkBoostTestDynamic=OFF"
+fi
+
 # In any case, we're in $SOURCE/build now.
 # Activate coverage iff compiling with linux/g++
 if [ "$TRAVIS_OS_NAME" = "linux" -a "$CXX" = "g++" ] ; then

--- a/_travis/compile
+++ b/_travis/compile
@@ -17,7 +17,7 @@ fi
 CMAKE_PARAMETERS="-DDownloadTestPDF=ON"
 
 if [ "$BOOST_STATIC" ] ; then
-	CMAKE_PARAMETERS="$CMAKE_PARAMETERS -DLinkBoostTestDynamic=OFF"
+	CMAKE_PARAMETERS="$CMAKE_PARAMETERS -DBoostStaticLink=ON"
 fi
 
 # In any case, we're in $SOURCE/build now.

--- a/_travis/test
+++ b/_travis/test
@@ -3,11 +3,18 @@ set -ex
 cd build
 
 [ -x ./dspdfviewer ]
+[ -x ./testing/testrunner ]
 
-if [ "$BOOST_STATIC" ] && [ $BOOST_STATIC -gt 0 ] ; then
-	[ 0 -eq $(ldd testing/testrunner | grep --count boost ) ]
+if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
+	# Verify whether the testrunner is linked
+	# statically or dynamically against boost
+	if [ "$BOOST_STATIC" ] && [ $BOOST_STATIC -gt 0 ] ; then
+		[ 0 -eq $(ldd testing/testrunner | grep --count boost ) ]
+	else
+		$(ldd testing/testrunner | grep -q boost)
+	fi
 else
-	$(ldd testing/testrunner | grep -q boost)
+	echo "FIXME: Don't know how to check linkage on $TRAVIS_OS_NAME"
 fi
 
 ctest --output-on-failure

--- a/_travis/test
+++ b/_travis/test
@@ -3,6 +3,13 @@ set -ex
 cd build
 
 [ -x ./dspdfviewer ]
+
+if [ "$BOOST_STATIC" ] && [ $BOOST_STATIC -gt 0 ] ; then
+	[ 0 -eq $(ldd testing/testrunner | grep --count boost ) ]
+else
+	$(ldd testing/testrunner | grep -q boost)
+fi
+
 ctest --output-on-failure
 if [ "$TRAVIS_OS_NAME" = "linux" -a "$CXX" = "g++" ] ; then
 	ctest -T coverage

--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -4,14 +4,19 @@
 
 
 ### Boost Libraries ###
+
+if( BoostStaticLink )
+	set(Boost_USE_STATIC_LIBS ON)
+elseif(BuildTests)
+	add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
+
 if(BuildTests)
-	# If we're building tests, we need program_options AND unit_test_framework
+	# If we're building tests, we need program_options
+	# AND unit_test_framework
 	find_package(Boost
 		COMPONENTS program_options unit_test_framework
 		REQUIRED)
-	if( LinkBoostTestDynamic )
-		add_definitions(-DBOOST_TEST_DYN_LINK)
-	endif()
 else()
 	# No unit tests: Only program_options needed
 	find_package(Boost

--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -9,6 +9,9 @@ if(BuildTests)
 	find_package(Boost
 		COMPONENTS program_options unit_test_framework
 		REQUIRED)
+	if( LinkBoostTestDynamic )
+		add_definitions(-DBOOST_TEST_DYN_LINK)
+	endif()
 else()
 	# No unit tests: Only program_options needed
 	find_package(Boost

--- a/testing/testhelpers.hh
+++ b/testing/testhelpers.hh
@@ -22,7 +22,6 @@
 #include <chrono>
 #include <iostream>
 
-#define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
 namespace TestHelpers {


### PR DESCRIPTION
Allows one to choose boost link type at `cmake` step. @projekter has shown it makes sense at least on windows, to link statically, because there's no standard package manager system that ensures dynamic libraries are present at run-time.

This is a part of #104 