### PR TITLE
travis.yml: Only build gh-pages and pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ script:
 branches:
   only:
     - gh-pages
-    - /^.*$/


### PR DESCRIPTION
This should fix double execution of travis on PRs, like in #106