### PR TITLE
Set library name to libdspdfviewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,11 +48,11 @@ endif()
 ### Compile all the source code into one .a file
 
 add_library(libdspdfviewer ${libdspdfviewer_SRCS} ${dspdfviewer_UIS_H} ${TRANSLATIONS})
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-	set_target_properties(libdspdfviewer PROPERTIES OUTPUT_NAME libdspdfviewer)
-else()
-	set_target_properties(libdspdfviewer PROPERTIES OUTPUT_NAME dspdfviewer)
-endif()
+# Set target name to "libdspdfviewer"
+# without a prefix (normally unix would auto-add lib...)
+set_target_properties(libdspdfviewer PROPERTIES
+	PREFIX ""
+	)
 target_link_libraries(libdspdfviewer ${LIST_LIBRARIES})
 
 ### And link it together with main.cpp to produce an executable


### PR DESCRIPTION
Without using any compiler- or OS-specific flags.