### PR TITLE
testhelpers.hh: Use relative path for headers

### DIFF
--- a/testing/testhelpers.hh
+++ b/testing/testhelpers.hh
@@ -1,23 +1,23 @@
 #pragma once
 
 /** Include all headers to access the dspdfviewer objects */
-#include <adjustedlink.h>
-#include <debug.h>
-#include <dspdfviewer.h>
-#include <hyperlinkarea.h>
-#include <pagepart.h>
-#include <pdfcacheoption.h>
-#include <pdfdocumentreference.h>
-#include <pdfpagereference.h>
-#include <pdfrenderfactory.h>
-#include <pdfviewerwindow.h>
-#include <renderedpage.h>
-#include <renderingidentifier.h>
-#include <renderthread.h>
-#include <renderutils.h>
-#include <runtimeconfiguration.h>
-#include <sconnect.h>
-#include <windowrole.h>
+#include "../adjustedlink.h"
+#include "../debug.h"
+#include "../dspdfviewer.h"
+#include "../hyperlinkarea.h"
+#include "../pagepart.h"
+#include "../pdfcacheoption.h"
+#include "../pdfdocumentreference.h"
+#include "../pdfpagereference.h"
+#include "../pdfrenderfactory.h"
+#include "../pdfviewerwindow.h"
+#include "../renderedpage.h"
+#include "../renderingidentifier.h"
+#include "../renderthread.h"
+#include "../renderutils.h"
+#include "../runtimeconfiguration.h"
+#include "../sconnect.h"
+#include "../windowrole.h"
 
 #include <chrono>
 #include <iostream>


### PR DESCRIPTION
These are clearly not system headers, so they should use the local include syntax.

Also, using the system header include style called build failures on certain compilers.