### PR TITLE
Add MinGW support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,12 @@
 #     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 # */
 cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
-cmake_policy(SET CMP0020 NEW) # qtmain.lib linkage on windows
-cmake_policy(SET CMP0054 NEW) # dont expand quoted strings in if()s
+if( NOT CMAKE_VERSION VERSION_LESS 2.8.11)
+	cmake_policy(SET CMP0020 NEW) # qtmain.lib linkage on windows
+endif()
+if( NOT CMAKE_VERSION VERSION_LESS 3.1)
+	cmake_policy(SET CMP0054 NEW) # dont expand quoted strings in if()s
+endif()
 
 project(dspdfviewer)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,12 @@
 #     with this program; if not, write to the Free Software Foundation, Inc.,
 #     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 # */
+cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
+cmake_policy(SET CMP0020 NEW) # qtmain.lib linkage on windows
+cmake_policy(SET CMP0054 NEW) # dont expand quoted strings in if()s
 
 project(dspdfviewer)
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+
 include(FindPkgConfig)
 set(CMAKE_AUTOMOC ON)#
 set(CMAKE_AUTORCC OFF)
@@ -32,7 +35,7 @@ option(BoostStaticLink "Link statically against the boost libraries" OFF)
 option(DownloadTestPDF "Download test PDFs from http://danny-edel.de, rather then building them using latex-beamer" OFF)
 option(CodeCoverage "Add coverage analysis code to the program. Will slow it down. A lot. Only supported on GCC right now." OFF)
 
-
+include(cmake/platforms.cmake)
 include(cmake/filelists.cmake)
 include(cmake/external_libraries.cmake)
 include(cmake/qrc_embedding.cmake)

--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -49,7 +49,6 @@ if(UseQtFive)
 		${Qt5Widgets_LIBRARIES}
 	)
 	add_definitions(-DPOPPLER_QT5)
-	add_definitions(-fPIC)
 	qt5_wrap_ui(dspdfviewer_UIS_H ${UIFILES})
 	if( UpdateTranslations )
 		qt5_create_translation(TRANSLATIONS ${libdspdfviewer_SRCS} ${dspdfviewer_SRCS} ${UIFILES} ${TRANSLATIONFILES})

--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -37,9 +37,17 @@ if(UseQtFive)
 	find_package(Qt5LinguistTools REQUIRED)
 	pkg_search_module(POPPLER REQUIRED poppler-qt5)
 	# add their include directories
-	list(APPEND LIST_INCLUDE_DIRS ${Qt5Core_INCLUDE_DIRS} ${Qt5Gui_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS})
+	list(APPEND LIST_INCLUDE_DIRS
+		${Qt5Core_INCLUDE_DIRS}
+		${Qt5Gui_INCLUDE_DIRS}
+		${Qt5Widgets_INCLUDE_DIRS}
+	)
 	# add their link flags
-	list(APPEND LIST_LIBRARIES ${Qt5Core_LIBRARIES} ${Qt5Gui_LIBRARIES} ${Qt5Widgets_LIBRARIES})
+	list(APPEND LIST_LIBRARIES
+		${Qt5Core_LIBRARIES}
+		${Qt5Gui_LIBRARIES}
+		${Qt5Widgets_LIBRARIES}
+	)
 	add_definitions(-DPOPPLER_QT5)
 	add_definitions(-fPIC)
 	qt5_wrap_ui(dspdfviewer_UIS_H ${UIFILES})

--- a/cmake/platforms.cmake
+++ b/cmake/platforms.cmake
@@ -1,0 +1,13 @@
+# If building on MSVC, WIN32 is defined, but on Cygwin/MSYS/MinGW it is not.
+
+# use the WINDOWS variable for everything on windows (regardless of which
+# compiler type), MSVC or MINGW for compiler-specific things.
+
+message(STATUS "Compiling for system ${CMAKE_SYSTEM_NAME}")
+if( CMAKE_SYSTEM_NAME STREQUAL "Windows" )
+	set(WINDOWS ON)
+elseif( CMAKE_SYSTEM_NAME STREQUAL "MSYS" )
+	set(WINDOWS ON)
+else()
+	set(WINDOWS OFF)
+endif()

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -91,7 +91,7 @@ add_test(NAME BoostTestRunner
 
 if(APPLE)
 	set(XVFB "")
-elseif(WIN32)
+elseif(WINDOWS)
 	set(XFFB "")
 else()
 	# Find xvfb-run

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -121,18 +121,25 @@ if( ENV_PROG STREQUAL "ENV_PROG-NOTFOUND" )
 	message(FATAL_ERROR "env not found")
 endif()
 
-add_test(NAME EnglishByDefault
-	COMMAND ${ENV_PROG} LANGUAGE=C LC_ALL=C.UTF-8 ${XVFB} ../dspdfviewer --help
-)
+# On windows you cannot change the locale on a case-by-case basis.
+#
+# FIXME: Windows: Discover current locale
+# FIXME: Windows: Include the translation test for the current locale
 
-set_tests_properties(EnglishByDefault PROPERTIES
-	PASS_REGULAR_EXPRESSION "Interactive Controls"
+if(NOT WINDOWS)
+	add_test(NAME EnglishByDefault
+		COMMAND ${ENV_PROG} LANGUAGE=C LC_ALL=C.UTF-8 ${XVFB} ../dspdfviewer --help
 	)
 
-add_test(NAME GermanWithDeDE
-	COMMAND ${ENV_PROG} LANGUAGE=de LC_ALL=de_DE.UTF-8 ${XVFB} ../dspdfviewer --help
-)
+	set_tests_properties(EnglishByDefault PROPERTIES
+		PASS_REGULAR_EXPRESSION "Interactive Controls"
+		)
 
-set_tests_properties(GermanWithDeDE PROPERTIES
-	PASS_REGULAR_EXPRESSION "Interaktive Tasten"
-)
+	add_test(NAME GermanWithDeDE
+		COMMAND ${ENV_PROG} LANGUAGE=de LC_ALL=de_DE.UTF-8 ${XVFB} ../dspdfviewer --help
+	)
+
+	set_tests_properties(GermanWithDeDE PROPERTIES
+		PASS_REGULAR_EXPRESSION "Interaktive Tasten"
+	)
+endif()

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -22,6 +22,13 @@ if(DownloadTestPDF)
 		EXPECTED_MD5 5c72e0954d457e3e9a1287ff299e307a
 		)
 else()
+	# Compile from source
+	find_program(PDFLATEX
+		NAMES pdflatex
+		)
+	if( PDFLATEX STREQUAL "PDFLATEX-NOTFOUND")
+		message(FATAL_ERROR "Compiling PDFs from source requires pdflatex with latex-beamer installed")
+	endif()
 	foreach(pdffile IN LISTS PDFFILENAMES)
 		# get source file name.
 		# replace .pdf with .tex ending,
@@ -36,7 +43,7 @@ else()
 		add_custom_command(OUTPUT ${pdffile}
 			DEPENDS ${SOURCEFULLPATH}
 			COMMAND # env TEXINPUTS=${SOURCEDIRNAME}
-				pdflatex
+				${PDFLATEX}
 				-interaction=nonstopmode
 				-output-directory ${CMAKE_CURRENT_BINARY_DIR}
 				${PDFLATEX_FIXED_FILENAME}


### PR DESCRIPTION
Add minimal support for the MSYS2/MinGW environment.

* Add a new CMake variable `WINDOWS` that gets activated on MSVC and MinGW
* Disable locale-switching unittests if `WINDOWS` (Switching locale works differently there)
* Throw error at cmake step if `pdflatex` is not found, but `DownloadTestPDF` is `OFF`.