### PR TITLE
Windows dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ debian/*.log
 # for example left behind from a failed
 # mk-build-deps
 *.deb
+
+# Windows compiled help files
+*.chm

--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -35,7 +35,57 @@ if(UseQtFive)
 	find_package(Qt5Gui REQUIRED)
 	find_package(Qt5Widgets REQUIRED)
 	find_package(Qt5LinguistTools REQUIRED)
-	pkg_search_module(POPPLER REQUIRED poppler-qt5)
+	if(WINDOWS)
+		set(POPPLER_LIBRARIES
+			optimized "C:/dspdf/poppler/poppler/lib/poppler.lib"
+			debug "C:/dspdf/poppler/poppler/lib/popplerd.lib"
+			optimized "C:/dspdf/poppler/poppler/lib/poppler-qt5.lib"
+			debug "C:/dspdf/poppler/poppler/lib/poppler-qt5d.lib"
+			optimized "C:/dspdf/poppler/deps/cairo/lib/cairo-static.lib"
+			debug "C:/dspdf/poppler/deps/cairo/lib/cairo-staticd.lib"
+			optimized "C:/dspdf/poppler/deps/freetype/lib/freetype.lib"
+			debug "C:/dspdf/poppler/deps/freetype/lib/freetyped.lib"
+			optimized "C:/dspdf/poppler/deps/lcms/Lib/MS/lcms2_static.lib"
+			debug "C:/dspdf/poppler/deps/lcms/Lib/MS/lcms2_staticd.lib"
+			optimized "C:/dspdf/poppler/deps/fontconfig/lib/libfontconfig.lib"
+			debug "C:/dspdf/poppler/deps/fontconfig/lib/libfontconfigd.lib"
+			optimized "C:/dspdf/poppler/deps/libpng/lib/libpng16_static.lib"
+			debug "C:/dspdf/poppler/deps/libpng/lib/libpng16_staticd.lib"
+			optimized "C:/dspdf/poppler/deps/libtiff/lib/tiff_static.lib"
+			debug "C:/dspdf/poppler/deps/libtiff/lib/tiff_staticd.lib"
+			optimized "C:/dspdf/poppler/deps/zlib/lib/zlibstatic.lib"
+			debug "C:/dspdf/poppler/deps/zlib/lib/zlibstaticd.lib"
+			optimized "C:/dspdf/poppler/deps/expat/lib/expat.lib"
+			debug "C:/dspdf/poppler/deps/expat/lib/expatd.lib"
+			optimized "C:/dspdf/poppler/deps/openjpeg/lib/openjp2.lib"
+			debug "C:/dspdf/poppler/deps/openjpeg/lib/openjp2d.lib"
+			optimized "C:/dspdf/poppler/deps/libtiff/lib/port.lib"
+			debug "C:/dspdf/poppler/deps/libtiff/lib/portd.lib"
+			optimized "C:/dspdf/poppler/deps/libiconv/lib/libiconvStatic.lib"
+			debug "C:/dspdf/poppler/deps/libiconv/lib/libiconvStaticD.lib"
+			optimized "C:/dspdf/poppler/deps/pixman/lib/pixman-1_static.lib"
+			debug "C:/dspdf/poppler/deps/pixman/lib/pixman-1_staticd.lib")
+		set(POPPLER_INCLUDE_DIRS "C:/dspdf/poppler/poppler/include/poppler/qt5")
+		list(APPEND LIST_LIBRARIES
+			optimized "C:/Qt/Static/qtbase/lib/Qt5XML.lib"
+	  		debug "C:/Qt/Static/qtbase/lib/Qt5XMLd.lib"
+  			optimized "C:/Qt/Static/qtbase/lib/Qt5PlatformSupport.lib"
+  			debug "C:/Qt/Static/qtbase/lib/Qt5PlatformSupportd.lib"
+	  		optimized "C:/Qt/Static/qtbase/plugins/platforms/qwindows.lib"
+  			debug "C:/Qt/Static/qtbase/plugins/platforms/qwindowsd.lib"
+  			optimized "C:/Qt/Static/qtbase/lib/qtpcre.lib"
+	  		debug "C:/Qt/Static/qtbase/lib/qtpcred.lib"
+  			optimized "C:/Qt/Static/qtbase/lib/qtharfbuzzng.lib"
+  			debug "C:/Qt/Static/qtbase/lib/qtharfbuzzngd.lib"
+	  		"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/WS2_32.Lib"
+  			"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/OpenGL32.Lib"
+  			"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/MSImg32.Lib"
+	  		"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/Imm32.Lib"
+  			"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/Winmm.Lib"
+		)
+	else()
+		pkg_search_module(POPPLER REQUIRED poppler-qt5)
+	endif()
 	# add their include directories
 	list(APPEND LIST_INCLUDE_DIRS
 		${Qt5Core_INCLUDE_DIRS}

--- a/docs/Windows/license.html
+++ b/docs/Windows/license.html
@@ -20,7 +20,6 @@
    <li>FreeType 2.6 &mdash; <a href="http://www.freetype.org/" target="_blank">Homepage</a> &bull; License: <tt>GPLv2.txt</tt></li>
    <li>lcms 2.7 &mdash; <a href="http://www.littlecms.com/" target="_blank">Homepage</a> &bull; License: <tt>lcms.txt</tt></li>
    <li>libiconv 1.14 &mdash; <a href="http://www.codeproject.com/Articles/302012/How-to-Build-libiconv-with-Microsoft-Visual-Studio" target="_blank">Homepage</a> &bull; License: <tt>libiconv.txt</tt></li>
-   <li>libjpeg-turbo 1.4.1 &mdash; <a href="http://libjpeg-turbo.virtualgl.org/" target="_blank">Homepage</a> &bull; License: <tt>libjpeg-turbo.txt</tt></li>
    <li>libpng 1.6.18 &mdash; <a href="http://libpng.sourceforge.net/" target="_blank">Homepage</a> &bull; License: <tt>libpng.txt</tt></li>
    <li>LibTIFF 4.0.5 &mdash; <a href="http://www.remotesensing.org/libtiff/" target="_blank">Homepage</a> &bull; License: <tt>libtiff.txt</tt></li>
    <li>OpenJPEG 2.1.0 &mdash; <a href="http://www.openjpeg.org/" target="_blank">Homepage</a> &bull; License: <tt>openjpeg.txt</tt></li>

--- a/pagepart.cpp
+++ b/pagepart.cpp
@@ -19,6 +19,7 @@
 
 
 #include "pagepart.h"
+#include <string>
 
 namespace {
 	const char * const left = "left";

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -109,7 +109,11 @@ void PDFViewerWindow::reposition()
   this->setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
   this->showNormal();
 #if defined(POPPLER_QT5) && defined(_WIN32)
-  this->windowHandle()->setScreen(QApplication::screens()[numeric_cast<int>(getMonitor())]);
+  static QList<QScreen *> screens = QApplication::screens();
+  if ( m_monitor < screens.count() )
+    this->windowHandle()->setScreen(screens[m_monitor]);
+  else
+    this->windowHandle()->setScreen(0);
   this->showFullScreen();
 #else
   QRect rect = QApplication::desktop()->screenGeometry( numeric_cast<int>(getMonitor()) );


### PR DESCRIPTION
Inclusion of Windows dependencies with absolute paths, first fix for #104.
Fixes a compile failure in c46de22266b43f253c4cb81c2636e7e5d83f8d3b.
Closes #99.