### PR TITLE
Fix linking to poppler on MinGW

### DIFF
--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -35,7 +35,7 @@ if(UseQtFive)
 	find_package(Qt5Gui REQUIRED)
 	find_package(Qt5Widgets REQUIRED)
 	find_package(Qt5LinguistTools REQUIRED)
-	if(WINDOWS)
+	if(MSVC)
 		set(POPPLER_LIBRARIES
 			optimized "C:/dspdf/poppler/poppler/lib/poppler.lib"
 			debug "C:/dspdf/poppler/poppler/lib/popplerd.lib"

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -110,7 +110,7 @@ void PDFViewerWindow::reposition()
   this->showNormal();
 #if defined(POPPLER_QT5) && defined(_WIN32)
   static QList<QScreen *> screens = QApplication::screens();
-  if ( m_monitor < screens.count() )
+  if ( m_monitor < numeric_cast<unsigned>(screens.count()) )
     this->windowHandle()->setScreen(screens[m_monitor]);
   else
     this->windowHandle()->setScreen(0);


### PR DESCRIPTION
Currently the list of statically linked `.lib` files gets activated if `WINDOWS` is defined.

However, `.lib` files are specific to the MSVC compiler, so compiling fails on MinGW. This PR sets the conditional to `if (MSVC)` and fixes a little build failure with MinGW.