### PR TITLE
Release v1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ inspect the output of commands like `git diff -w v1.11..v1.12` directly.
 
 
 
+v1.14 - 2015-12-01
+------------------
+
+New features:
+
+* Translation support
+  * For now, a german translation is included, thanks to projekter.
+* Experimental i3 support
+  * If you specify the --i3-workaround=true option, dspdfviewer will try to
+    use i3-cmd to move the audience window one screen to the right.
+  * This code is not well tested, please leave feedback and suggestions.
+* Add support for Qt5
+* Add support for Windows, thanks to projekter.
+
+
 v1.13.1 - 2015-08-06
 --------------------
 

--- a/cmake/version_number.cmake
+++ b/cmake/version_number.cmake
@@ -30,7 +30,7 @@ if( NOT DSPDFVIEWER_VERSION )
 	# Use default
 
 	# TODO: Keep me updated!
-	set(DSPDFVIEWER_VERSION "1.14-unreleased")
+	set(DSPDFVIEWER_VERSION "1.14")
 	message(STATUS "Embedding version number ${DSPDFVIEWER_VERSION}. If you want to override this, "
 		"for example to embed the git revision you built from, please pass "
 		"-DDSPDFVIEWER_VERSION=1.2.3.4.5 to the cmake command.")


### PR DESCRIPTION
The number of changes (especially the Qt5 and Windows ports) justify releasing a new version.

I tested building on Debian myself, and I know from @projekter's #122 that it works on Windows.

@wwwdata can you verify this PR builds correctly on OSX? If I get your okay I'll release tomorrow.

* Please note there is now a testsuite, and if you don't specify `-DDownloadTestPDF=ON` on the cmake command line, you need a working latex-beamer installation at build time.
* If you want to build against Qt5, specify `-DUseQtFive=ON` at cmake time.