### PR TITLE
Fixed inclusion of directories in MSVC

### DIFF
--- a/cmake/compiler_msvc.cmake
+++ b/cmake/compiler_msvc.cmake
@@ -9,3 +9,5 @@ if(CompileMTMode)
 		endif()
 	endforeach()
 endif()
+
+include_directories(${LIST_INCLUDE_DIRS})


### PR DESCRIPTION
Sorry for this, but you were right in #122. For some reason, it always compiled without this include_directories or it was lost in one of the most recent commits (which I cannot remember). But it is definitely needed.