### PR TITLE
d/control: Add xvfb dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,8 @@ Build-Depends: cmake,
                libpoppler-qt4-dev,
                lsb-release,
                pkg-config,
-               texlive-pictures
+               texlive-pictures,
+               xvfb
 Standards-Version: 3.9.3
 Vcs-Git: git://github.com/dannyedel/dspdfviewer.git
 Vcs-Browser: https://github.com/dannyedel/dspdfviewer


### PR DESCRIPTION
This should™ allow the jenkins daily builds to work correctly again (as in, execute the test suites)