### PR TITLE
Add xauth dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends: cmake,
                lsb-release,
                pkg-config,
                texlive-pictures,
+               xauth,
                xvfb
 Standards-Version: 3.9.3
 Vcs-Git: git://github.com/dannyedel/dspdfviewer.git


### PR DESCRIPTION
This is also needed for the jenkins debian test system. #127 was incomplete.