### PR TITLE
boost-test: print colors as hex values

### DIFF
--- a/testing/test-images.cc
+++ b/testing/test-images.cc
@@ -9,14 +9,14 @@ BOOST_AUTO_TEST_CASE(image_rendering) {
 	auto first = RenderUtils::renderPagePart(pdr.page(0).page, QSize(1920,1080), PagePart::LeftHalf);
 	auto second = RenderUtils::renderPagePart(pdr.page(1).page, QSize(1920,1080), PagePart::LeftHalf);
 
-	auto firstColor = QColor( 0x70, 0x1e, 0xc1).rgb();
-	auto secondColor = QColor( 0x14, 0x63, 0xb4).rgb();
+	auto firstColor = QColor( 0x70, 0x1e, 0xc1);
+	auto secondColor = QColor( 0x14, 0x63, 0xb4);
 	
 	/** Check sizes of rendered images **/
 	BOOST_CHECK_EQUAL( QSize(1920,1080), first.size());
 	BOOST_CHECK_EQUAL( QSize(1920,1080), second.size());
 
 	/** Check pixels in the middle */
-	BOOST_CHECK_EQUAL( firstColor, first.pixel(960,540));
-	BOOST_CHECK_EQUAL( secondColor, second.pixel(960,540));
+	BOOST_CHECK_EQUAL( firstColor, QColor(first.pixel(960,540)));
+	BOOST_CHECK_EQUAL( secondColor, QColor(second.pixel(960,540)));
 }

--- a/testing/testhelpers.hh
+++ b/testing/testhelpers.hh
@@ -55,3 +55,16 @@ namespace TestHelpers {
 
 /** Print a QSize to a standard output stream */
 std::ostream& operator << (std::ostream& where, const QSize& what);
+
+/** Print QRgb values as #123456 html-style-strings within boost test
+ * log messages */
+namespace boost{
+	namespace test_tools{
+		template<>
+		inline
+		void
+		print_log_value<QColor>::operator()(std::ostream& where, const QColor& what) {
+			where << what.name().toStdString();
+		}
+	}
+}

--- a/testing/testrenderonepage.cc
+++ b/testing/testrenderonepage.cc
@@ -10,8 +10,8 @@ BOOST_AUTO_TEST_CASE(render_one_page) {
 	auto right = RenderUtils::renderPagePart(pdr.page(0).page, QSize(1920,1200), PagePart::RightHalf);
 	auto both = RenderUtils::renderPagePart(pdr.page(0).page, QSize(3840,1080), PagePart::FullPage);
 
-	auto leftScreenColor = QColor( 0x88, 0xff, 0x88).rgb();
-	auto rightScreenColor = QColor( 0xff, 0x88, 0xff).rgb();
+	auto leftScreenColor = QColor( 0x88, 0xff, 0x88);
+	auto rightScreenColor = QColor( 0xff, 0x88, 0xff);
 
 	/** Check sizes of rendered images **/
 	BOOST_CHECK_EQUAL( QSize(1920,1080), left.size());
@@ -19,18 +19,18 @@ BOOST_AUTO_TEST_CASE(render_one_page) {
 	BOOST_CHECK_EQUAL( QSize(3840,1080), both.size());
 
 	/** Check pixels in the middle */
-	BOOST_CHECK_EQUAL( leftScreenColor, left.pixel(960,540));
-	BOOST_CHECK_EQUAL( rightScreenColor, right.pixel(960,540));
-	BOOST_CHECK_EQUAL( leftScreenColor, both.pixel(960,540));
-	BOOST_CHECK_EQUAL( rightScreenColor, both.pixel(2880,540));
+	BOOST_CHECK_EQUAL( leftScreenColor, QColor(left.pixel(960,540)));
+	BOOST_CHECK_EQUAL( rightScreenColor, QColor(right.pixel(960,540)));
+	BOOST_CHECK_EQUAL( leftScreenColor, QColor(both.pixel(960,540)));
+	BOOST_CHECK_EQUAL( rightScreenColor, QColor(both.pixel(2880,540)));
 
 	/** Check all-the-way-left and all-the-way-right pixel colors */
-	BOOST_CHECK_EQUAL( leftScreenColor, left.pixel(0,540));
-	BOOST_CHECK_EQUAL( leftScreenColor, left.pixel(1919,540));
+	BOOST_CHECK_EQUAL( leftScreenColor, QColor(left.pixel(0,540)));
+	BOOST_CHECK_EQUAL( leftScreenColor, QColor(left.pixel(1919,540)));
 
-	BOOST_CHECK_EQUAL( rightScreenColor, right.pixel(0,540));
-	BOOST_CHECK_EQUAL( rightScreenColor, right.pixel(1919,540));
+	BOOST_CHECK_EQUAL( rightScreenColor, QColor(right.pixel(0,540)));
+	BOOST_CHECK_EQUAL( rightScreenColor, QColor(right.pixel(1919,540)));
 
-	BOOST_CHECK_EQUAL( leftScreenColor, both.pixel(0,540));
-	BOOST_CHECK_EQUAL( rightScreenColor, both.pixel(3839,540));
+	BOOST_CHECK_EQUAL( leftScreenColor, QColor(both.pixel(0,540)));
+	BOOST_CHECK_EQUAL( rightScreenColor, QColor(both.pixel(3839,540)));
 }


### PR DESCRIPTION
This improves the failed unit test output by providing colors as `#aabbcc` instead of a decimal number.