### PR TITLE
testsuite: Allow white note page

### DIFF
--- a/_travis/compile
+++ b/_travis/compile
@@ -14,7 +14,7 @@ else
 	cd build
 fi
 
-CMAKE_PARAMETERS="-DDownloadTestPDF=ON"
+CMAKE_PARAMETERS="-DDownloadTestPDF=OFF"
 
 if [ "$BOOST_STATIC" ] ; then
 	CMAKE_PARAMETERS="$CMAKE_PARAMETERS -DBoostStaticLink=ON"

--- a/_travis/compile
+++ b/_travis/compile
@@ -14,7 +14,13 @@ else
 	cd build
 fi
 
-CMAKE_PARAMETERS="-DDownloadTestPDF=OFF"
+CMAKE_PARAMETERS=""
+
+if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+	# on OSX: Download Test PDF (installing pdflatex using
+	# brew would take too long)
+	CMAKE_PARAMETERS="${CMAKE_PARAMETERS} -DDownloadTestPDF=ON"
+fi
 
 if [ "$BOOST_STATIC" ] ; then
 	CMAKE_PARAMETERS="$CMAKE_PARAMETERS -DBoostStaticLink=ON"

--- a/_travis/install_dependencies
+++ b/_travis/install_dependencies
@@ -11,9 +11,11 @@ install_via_aptget() {
 
 if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
 	# Update list of available packages in any case
-	DEPS="libboost-program-options-dev libboost-test-dev pkg-config xvfb"
+	DEPS="libboost-program-options-dev libboost-test-dev \
+		pkg-config xvfb xauth latex-beamer texlive-pictures"
 	if [ "$QT_VERSION" -eq 5 ] ; then
-		DEPS="${DEPS} libpoppler-qt5-dev qtbase5-dev qttools5-dev qttools5-dev-tools"
+		DEPS="${DEPS} libpoppler-qt5-dev qtbase5-dev \
+			qttools5-dev qttools5-dev-tools"
 	else
 		DEPS="${DEPS} libpoppler-qt4-dev"
 	fi

--- a/testing/testrenderonepage.cc
+++ b/testing/testrenderonepage.cc
@@ -6,22 +6,38 @@ using namespace TestHelpers;
 BOOST_AUTO_TEST_CASE(render_one_page) {
 	PDFDocumentReference pdr( TestHelpers::pdfFilename("colored-rectangles.pdf"), PDFCacheOption::keepPDFinMemory );
 
-	auto left = RenderUtils::renderPagePart(pdr.page(0).page, QSize(1920,1080), PagePart::LeftHalf);
-	auto right = RenderUtils::renderPagePart(pdr.page(0).page, QSize(1920,1200), PagePart::RightHalf);
-	auto both = RenderUtils::renderPagePart(pdr.page(0).page, QSize(3840,1080), PagePart::FullPage);
+	const auto left = RenderUtils::renderPagePart(pdr.page(0).page, QSize(1920,1080), PagePart::LeftHalf);
+	const auto right = RenderUtils::renderPagePart(pdr.page(0).page, QSize(1920,1200), PagePart::RightHalf);
+	const auto both = RenderUtils::renderPagePart(pdr.page(0).page, QSize(3840,1080), PagePart::FullPage);
 
-	auto leftScreenColor = QColor( 0x88, 0xff, 0x88);
+	const auto leftScreenColor = QColor( 0x88, 0xff, 0x88);
 	auto rightScreenColor = QColor( 0xff, 0x88, 0xff);
+
+	/** Older texlive installation: Note page gets rendered white
+	 */
+	const auto fallbackRightScreenColor = QColor( 0xff, 0xff, 0xff);
+
+	BOOST_CHECK_NE(rightScreenColor, fallbackRightScreenColor);
 
 	/** Check sizes of rendered images **/
 	BOOST_CHECK_EQUAL( QSize(1920,1080), left.size());
 	BOOST_CHECK_EQUAL( QSize(1920,1080), right.size());
 	BOOST_CHECK_EQUAL( QSize(3840,1080), both.size());
 
-	/** Check pixels in the middle */
+	/** Check middle pixel of left screen **/
 	BOOST_CHECK_EQUAL( leftScreenColor, QColor(left.pixel(960,540)));
-	BOOST_CHECK_EQUAL( rightScreenColor, QColor(right.pixel(960,540)));
 	BOOST_CHECK_EQUAL( leftScreenColor, QColor(both.pixel(960,540)));
+
+	const auto rightScreenMiddle = QColor(right.pixel(960,540));
+
+	BOOST_WARN_EQUAL( rightScreenColor, rightScreenMiddle );
+	/** Check middle pixel of right screen **/
+	if ( rightScreenMiddle == fallbackRightScreenColor) {
+		BOOST_TEST_MESSAGE( "Middle of note screen was peak white, "
+			", using workaround for older latex-beamer versions.");
+		rightScreenColor = fallbackRightScreenColor;
+	}
+	BOOST_CHECK_EQUAL( rightScreenColor, QColor(right.pixel(960,540)));
 	BOOST_CHECK_EQUAL( rightScreenColor, QColor(both.pixel(2880,540)));
 
 	/** Check all-the-way-left and all-the-way-right pixel colors */


### PR DESCRIPTION
This allows for the note page from `colored-rectangles.pdf` to be rendered `0xffffff` (white), which happens on minimally older latex-beamer installations (they ignore note page background color)

Since this is not a dspdfviewer issue, allow the test suite to pass in this case, with a warning.

also update travis to build the PDF during the test run (this should work on precise and trusty now)