### PR TITLE
Change ordering of "Move to top left" and "Show fullscreen" commands

### DIFF
--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -117,9 +117,9 @@ void PDFViewerWindow::reposition()
   this->showFullScreen();
 #else
   QRect rect = QApplication::desktop()->screenGeometry( numeric_cast<int>(getMonitor()) );
-  this->showFullScreen();
   move(rect.topLeft());
   resize( rect.size() );
+  this->showFullScreen();
 #endif
   /* Note: The focus should be on the primary window, because at least
    * Gnome draws the primary window's border onto the secondary.


### PR DESCRIPTION
This should fix the problem that sometimes™ (depending on execution
speed -- race condition) a window would stay on its screen and/or end up
un-fullscreened on the correct screen.

This change does not affect Windows, because it's in the `#else` path, but it does affect OSX.

@wwwdata, can you check whether this correctly shows the window on the second screen in OSX when building (a) with qt4 / (b) with qt5?

If it works in qt4, but not qt5, please try whether the win32-style screen setting works.