### PR TITLE
Improve memory handling

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -8,6 +8,7 @@
  * qDebug()'s definition.
  */
 #define DEBUGOUT qDebug()
+#define WARNINGOUT qWarning() << "WARNING"
 
 #else
 
@@ -27,6 +28,12 @@
 #endif
 
 #define DEBUGOUT qDebug() << \
+ QString::fromUtf8("%1:%2 [%3()]"). \
+ arg(QFileInfo( QString::fromUtf8(__FILE__) ).fileName()). \
+ arg(QString::number( __LINE__ )). \
+ arg(QString::fromUtf8(__func__) )
+
+#define WARNINGOUT qWarning() << "WARNING" << \
  QString::fromUtf8("%1:%2 [%3()]"). \
  arg(QFileInfo( QString::fromUtf8(__FILE__) ).fileName()). \
  arg(QString::number( __LINE__ )). \

--- a/docs/dspdfviewer.1
+++ b/docs/dspdfviewer.1
@@ -146,6 +146,21 @@ Note: If you set this to zero, you will not get a thumbnail for the next page
 rendered before you have visited it.
 
 .TP
+.B \-\-cache\-size \fIn\fR (in megabytes / MiB)
+This controls how much memory dspdfviewer is allowed to use for caching rendered pages.
+The default value is 1024, meaning 1 GiB of RAM.
+Note that the memory used for active rendering processes, as well as the currently
+displayed images are not included in the accounting, so the total memory usage
+of dspdfviewer will be higher than this.
+
+CAVEAT: It is currently not verified that this memory is enough to hold all
+prerendered pages.
+If you make the cache too small to hold the prerendered pages,
+it will start dropping the first rendered (adjacent to the current page),
+resulting in very poor performance.
+If in doubt, set a larger cache or a lower prerender amount.
+
+.TP
 .B \-a, \-\-presenter-area \fI<bool>\fR
 Show (true, 1) or hide (false, 0) the presenter's area on the second screen.
 If this is set to zero, the following options will have no effect.

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -203,7 +203,7 @@ void DSPDFViewer::gotoPage(unsigned int pageNumber)
     m_pagenumber = pageNumber;
     renderPage();
   } else {
-    qWarning() << tr("Requested page number %1 which is out of range! Ignoring request.").arg(pageNumber);
+    WARNINGOUT << tr("Requested page number %1 which is out of range! Ignoring request.").arg(pageNumber);
   }
 }
 

--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -44,7 +44,7 @@ DSPDFViewer::DSPDFViewer(const RuntimeConfiguration& r):
 	presentationStart(),
 	presentationClockRunning(false),
 	documentFileWatcher(),
- renderFactory(r.filePathQString(), r.cachePDFToMemory()?PDFCacheOption::keepPDFinMemory:PDFCacheOption::rereadFromDisk ),
+ renderFactory(r),
  m_pagenumber(0),
  audienceWindow(1,   r.useFullPage()                 ? PagePart::FullPage : PagePart::LeftHalf , false, r, WindowRole::AudienceWindow),
  secondaryWindow(0, (r.useFullPage() | r.duplicate())? PagePart::FullPage : PagePart::RightHalf, true , r, WindowRole::PresenterWindow, r.useSecondScreen())

--- a/main.cpp
+++ b/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
 	if ( !qtTranslator.load(
 			QString::fromUtf8( "qt_" ) + localeName, systemTranslationsPath )
 			) {
-		qWarning() << "Failed to load qt translations for locale" << localeName;
+		WARNINGOUT << "Failed to load qt translations for locale" << localeName;
 	} else {
 		app.installTranslator(&qtTranslator);
 		DEBUGOUT << "Qt system translation loaded for" << localeName;
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
 	QTranslator appTranslator;
 	DEBUGOUT << "Loading dspdfviewer translation for current locale:" << localeName;
 	if ( ! appTranslator.load(QString::fromUtf8(":/translations/dspdfviewer") ) ) {
-		qWarning() << "Failed to load dspdfviewer translation for current locale" << localeName;
+		WARNINGOUT << "Failed to load dspdfviewer translation for current locale" << localeName;
 	} else {
 		app.installTranslator(&appTranslator);
 		DEBUGOUT << "dspdfviewer translation loaded for" << localeName;

--- a/pdfdocumentreference.cpp
+++ b/pdfdocumentreference.cpp
@@ -83,9 +83,11 @@ bool operator==(const PDFDocumentReference& lhs, const PDFDocumentReference& rhs
     return false;
   }
   else if ( lhs.cacheOption() == PDFCacheOption::keepPDFinMemory ) {
+	  DEBUGOUT << "Using memory cache, comparing byte-by-byte.";
     return lhs.fileContents_ == rhs.fileContents_;
   }
   else {
+	  DEBUGOUT << "Not using memory cache, just comparing the filename.";
     return lhs.filename() == rhs.filename();
   }
 }

--- a/pdfdocumentreference.cpp
+++ b/pdfdocumentreference.cpp
@@ -5,7 +5,7 @@
 #include <QFile>
 #include "debug.h"
 
-QSharedPointer< Poppler::Document > PDFDocumentReference::popplerDocument() const
+QSharedPointer< const Poppler::Document > PDFDocumentReference::popplerDocument() const
 {
   QSharedPointer<Poppler::Document> m_document;
 

--- a/pdfdocumentreference.cpp
+++ b/pdfdocumentreference.cpp
@@ -74,6 +74,7 @@ PDFDocumentReference& PDFDocumentReference::operator=(const PDFDocumentReference
     throw std::runtime_error("This PDFDocumentReference has a different cache setting");
   }
   fileContents_=rhs.fileContents_;
+  popplerDocument_=rhs.popplerDocument_;
   return *this;
 }
 

--- a/pdfdocumentreference.h
+++ b/pdfdocumentreference.h
@@ -5,6 +5,8 @@
 #include "pdfcacheoption.h"
 #include "poppler-qt.h"
 
+#include <mutex>
+
 // forward-declare
 struct PDFPageReference;
 
@@ -24,6 +26,10 @@ private:
   const QString filename_;
   QByteArray fileContents_;
   const PDFCacheOption cacheOption_;
+  // protects access to the poppler document
+  mutable std::mutex mutex_;
+  typedef std::lock_guard<std::mutex> Lock;
+  mutable QSharedPointer<const Poppler::Document> popplerDocument_;
 
 public:
   /** Create the document reference.

--- a/pdfdocumentreference.h
+++ b/pdfdocumentreference.h
@@ -62,14 +62,6 @@ public:
    */
   PDFDocumentReference& operator = (const PDFDocumentReference& rhs);
 
-  /** Since we define a custom copy-assignment, tell the compiler
-   * explicitly that the standard copy-construct is all right
-   */
-  PDFDocumentReference(const PDFDocumentReference& ) =default;
-#ifndef _MSC_VER
-  PDFDocumentReference(PDFDocumentReference&&) =default;
-#endif
-
   /** Compares the references. Exact behaviour depends on the cache option:
    * If we are memory-caching, this compares the ByteArrays (i.e. checks for
    * identical files).

--- a/pdfdocumentreference.h
+++ b/pdfdocumentreference.h
@@ -42,7 +42,7 @@ public:
    * If you did not cache the file to memory, this step will try to
    * read the file.
    */
-  QSharedPointer<Poppler::Document> popplerDocument() const;
+  QSharedPointer<const Poppler::Document> popplerDocument() const;
 
   /** get filename */
   const QString& filename() const;

--- a/pdfpagereference.h
+++ b/pdfpagereference.h
@@ -12,8 +12,8 @@
  */
 struct PDFPageReference
 {
-  const QSharedPointer<Poppler::Document> document;
-  const QSharedPointer<Poppler::Page> page;
+  const QSharedPointer<const Poppler::Document> document;
+  const QSharedPointer<const Poppler::Page> page;
 
 
   PDFPageReference( const PDFDocumentReference& documentReference, const unsigned int& pageNumber );

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -37,8 +37,9 @@ namespace {
 	 * overhead.
 	 */
 	int cacheCost(const RenderedPage& renderedPage) {
-		const QSize imageSize = renderedPage.getImage().size();
-		return 4 * imageSize.width() * imageSize.height();
+		const QSize& imageSize = renderedPage.getImage().size();
+		return sizeof(RenderedPage) +
+			4 * imageSize.width() * imageSize.height();
 	}
 }
 

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -85,7 +85,7 @@ PdfRenderFactory::PdfRenderFactory( const RuntimeConfiguration& rc):
 	fileWatcher(),
 	fileWatcherRewatchTimer(),
 	currentlyRenderingPages(),
-	renderedPages(),
+	renderedPages(rc.cacheSizeBytes()),
 	mutex(),
 	currentVersion(0),
 	// Attempt to read the document to get the number of pages within.

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -33,12 +33,12 @@
 namespace {
 	/** Estimates size in bytes of a rendered Page
 	 *
-	 * This currently assumes 24 bit (3 byte) per pixel, and no
+	 * This currently assumes 32 bit (4 byte) per pixel, and no
 	 * overhead.
 	 */
 	int cacheCost(const RenderedPage& renderedPage) {
 		const QSize imageSize = renderedPage.getImage().size();
-		return 3 * imageSize.width() * imageSize.height();
+		return 4 * imageSize.width() * imageSize.height();
 	}
 }
 

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -54,13 +54,16 @@ void PdfRenderFactory::pageThreadFinishedRendering(QSharedPointer<RenderedPage> 
     renderedPages.insert(ident, new RenderedPage(*renderedPage), cacheCost(*renderedPage) );
     currentlyRenderingPages.remove(ident);
 	if ( renderedPages.contains(ident) ) {
-		DEBUGOUT << "Stored" << ident << "into cache, new load" <<
-			renderedPages.totalCost() << "/" << renderedPages.maxCost();
+		DEBUGOUT << "Stored" << ident << "into cache";
 	} else {
 		WARNINGOUT << "Unable to store" << ident << "into the cache! It would cost" <<
 			cacheCost(*renderedPage) << "but Current load is" <<
 			renderedPages.totalCost() << "/" << renderedPages.maxCost();
 	}
+
+	DEBUGOUT << "Current cache fill is " <<
+		renderedPages.totalCost() << "/" << renderedPages.maxCost() << '(' <<
+		100.0 * renderedPages.totalCost() / renderedPages.maxCost() << "% )";
   }
 
   emit pageRendered(renderedPage);

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -78,9 +78,9 @@ void PdfRenderFactory::rewatchFile()
 
 
 
-PdfRenderFactory::PdfRenderFactory(const QString& filename, const PDFCacheOption& cacheSetting):
+PdfRenderFactory::PdfRenderFactory( const RuntimeConfiguration& rc):
 	QObject(),
-	documentReference(filename, cacheSetting),
+	documentReference(rc.filePathQString(), rc.cacheSetting()),
 	fileWatcher(),
 	fileWatcherRewatchTimer(),
 	currentlyRenderingPages(),

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -38,7 +38,7 @@ namespace {
 	 */
 	int cacheCost(const RenderedPage& renderedPage) {
 		const QSize& imageSize = renderedPage.getImage().size();
-		return sizeof(RenderedPage) +
+		return boost::numeric_cast<int>(sizeof(RenderedPage)) +
 			4 * imageSize.width() * imageSize.height();
 	}
 }

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -26,6 +26,7 @@
 #include <QThreadPool>
 #include <stdexcept>
 #include "debug.h"
+#include "renderutils.h"
 
 namespace {
 	/** Estimates size in bytes of a rendered Page
@@ -207,4 +208,8 @@ int PdfRenderFactory::numberOfPages() const
 {
   QMutexLocker lock(&mutex);
   return numberOfPages_;
+}
+
+PdfRenderFactory::~PdfRenderFactory() {
+	RenderUtils::notifyShutdown();
 }

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -170,7 +170,9 @@ void PdfRenderFactory::fileOnDiskChanged(const QString& filename)
 	  DEBUGOUT << "The new document compares identical to the old one, not doing anything.";
 	  return;
 	}
+
       }
+	DEBUGOUT << "The file on disk has different contents. Trying to parse it as PDF.";
 
       // Verify poppler can read this
       newDoc.popplerDocument();
@@ -179,6 +181,7 @@ void PdfRenderFactory::fileOnDiskChanged(const QString& filename)
       documentReference = newDoc;
 
       numberOfPages_ = documentReference.popplerDocument()->numPages();
+	  DEBUGOUT << "New document has" << numberOfPages_ << "pages.";
 
       // clear the page cache
       clearAllCaches();

--- a/pdfrenderfactory.cpp
+++ b/pdfrenderfactory.cpp
@@ -28,6 +28,8 @@
 #include "debug.h"
 #include "renderutils.h"
 
+#include <boost/cast.hpp>
+
 namespace {
 	/** Estimates size in bytes of a rendered Page
 	 *
@@ -85,7 +87,7 @@ PdfRenderFactory::PdfRenderFactory( const RuntimeConfiguration& rc):
 	fileWatcher(),
 	fileWatcherRewatchTimer(),
 	currentlyRenderingPages(),
-	renderedPages(rc.cacheSizeBytes()),
+	renderedPages( boost::numeric_cast<int>(rc.cacheSizeBytes()) ),
 	mutex(),
 	currentVersion(0),
 	// Attempt to read the document to get the number of pages within.

--- a/pdfrenderfactory.h
+++ b/pdfrenderfactory.h
@@ -30,6 +30,7 @@
 #include <qimage.h>
 #include "poppler-qt.h"
 #include "renderedpage.h"
+#include "runtimeconfiguration.h"
 #include "pdfcacheoption.h"
 #include "pdfdocumentreference.h"
 
@@ -91,7 +92,7 @@ private:
   void clearAllCaches();
 
 public:
-  PdfRenderFactory( const QString& filename, const PDFCacheOption& cacheSetting );
+  PdfRenderFactory( const RuntimeConfiguration& );
 
   /** Request a page rendering. Defaults to low priority (i.e. background rendering), please set High priority manually
    * on the current page.

--- a/pdfrenderfactory.h
+++ b/pdfrenderfactory.h
@@ -93,6 +93,7 @@ private:
 
 public:
   PdfRenderFactory( const RuntimeConfiguration& );
+  ~PdfRenderFactory();
 
   /** Request a page rendering. Defaults to low priority (i.e. background rendering), please set High priority manually
    * on the current page.

--- a/pdfviewerwindow.cpp
+++ b/pdfviewerwindow.cpp
@@ -497,7 +497,7 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
   for( AdjustedLink const & link: links ) {
     const QRectF& rect = link.linkArea();
     if ( rect.isNull() ) {
-      qWarning() << "Null Link Area not supported yet.";
+      WARNINGOUT << "Null Link Area not supported yet.";
       continue;
     }
     const Poppler::Link::LinkType& type = link.link()->linkType();
@@ -505,7 +505,7 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
       // type is Goto. Bind it to imageLabel
       const Poppler::LinkGoto& linkGoto = dynamic_cast<const Poppler::LinkGoto&>( * link.link() );
       if( linkGoto.isExternal() ) {
-	qWarning() << "External links are not supported yet.";
+	WARNINGOUT << "External links are not supported yet.";
 	continue;
       }
       HyperlinkArea* linkArea = new HyperlinkArea(ui.imageLabel, link);
@@ -513,7 +513,7 @@ void PDFViewerWindow::parseLinks(QList< AdjustedLink > links)
       newLinkAreas.append(linkArea);
     }
     else {
-      qWarning() << "Types other than Goto are not supported yet.";
+      WARNINGOUT << "Types other than Goto are not supported yet.";
       continue;
     }
   }

--- a/renderingidentifier.cpp
+++ b/renderingidentifier.cpp
@@ -21,6 +21,8 @@
 #include "renderingidentifier.h"
 #include <QApplication>
 #include <QHash>
+#include <QDebugStateSaver>
+#include <sstream>
 
 bool RenderingIdentifier::operator==(const RenderingIdentifier& other) const
 {
@@ -80,4 +82,11 @@ uint qHash(const RenderingIdentifier& ri)
   return qHash(ri.pageNumber()) ^ qHash(ri.requestedPageSize().height()) ^ qHash(ri.requestedPageSize().width());
 }
 
-
+QDebug operator << (QDebug d, const RenderingIdentifier& ri) {
+	QDebugStateSaver s(d);
+	std::ostringstream oss;
+	oss << ri.pagePart();
+	d.nospace() << "[page " << ri.pageNumber() << '/' << oss.str().c_str() << '/' <<
+		ri.requestedPageSize().width() << 'x' << ri.requestedPageSize().height() << ']';
+	return d;
+}

--- a/renderingidentifier.cpp
+++ b/renderingidentifier.cpp
@@ -21,8 +21,13 @@
 #include "renderingidentifier.h"
 #include <QApplication>
 #include <QHash>
-#include <QDebugStateSaver>
 #include <sstream>
+
+#if defined ( POPPLER_QT5 )
+#include <QDebugStateSaver>
+#else
+#include <QDebug>
+#endif
 
 bool RenderingIdentifier::operator==(const RenderingIdentifier& other) const
 {
@@ -83,7 +88,10 @@ uint qHash(const RenderingIdentifier& ri)
 }
 
 QDebug operator << (QDebug d, const RenderingIdentifier& ri) {
+#if defined ( POPPLER_QT5 )
+	// QDebugStateSaver only exists in Qt5.1
 	QDebugStateSaver s(d);
+#endif
 	std::ostringstream oss;
 	oss << ri.pagePart();
 	d.nospace() << "[page " << ri.pageNumber() << '/' << oss.str().c_str() << '/' <<

--- a/renderingidentifier.h
+++ b/renderingidentifier.h
@@ -55,4 +55,7 @@ public:
 /** Hashes this object to something useable in the cache */
 uint qHash(const RenderingIdentifier& ri);
 
+/** allow outputting a rendering identifier */
+QDebug operator << ( QDebug, const RenderingIdentifier&);
+
 #endif // RENDERINGIDENTIFIER_H

--- a/renderthread.cpp
+++ b/renderthread.cpp
@@ -23,7 +23,7 @@
 #include "adjustedlink.h"
 #include "debug.h"
 
-RenderThread::RenderThread(PDFDocumentReference theDocument, RenderingIdentifier renderIdent):
+RenderThread::RenderThread(const PDFDocumentReference& theDocument, const RenderingIdentifier& renderIdent):
   QObject(),
   QRunnable(),
   m_page( theDocument.page( renderIdent.pageNumber() ) ),

--- a/renderthread.cpp
+++ b/renderthread.cpp
@@ -37,7 +37,7 @@ void RenderThread::run()
   QImage renderImage = RenderUtils::renderPagePart(m_page.page, renderMe.requestedPageSize(), renderMe.pagePart());
   if ( renderImage.isNull() )
   {
-    qWarning() << "RenderThread for " << renderMe.pageNumber() <<
+    WARNINGOUT << "RenderThread for " << renderMe.pageNumber() <<
 		renderMe.requestedPageSize().width() << renderMe.requestedPageSize().height() << " failed";
     QSharedPointer<RenderingIdentifier> ri( new RenderingIdentifier(renderMe) );
     emit renderingFailed(ri);

--- a/renderthread.h
+++ b/renderthread.h
@@ -35,7 +35,7 @@ private:
   RenderingIdentifier renderMe;
 
 public:
-  RenderThread( PDFDocumentReference theDocument, RenderingIdentifier renderIdent);
+  RenderThread( const PDFDocumentReference& theDocument, const RenderingIdentifier& renderIdent);
 
   void run();
 

--- a/renderutils.cpp
+++ b/renderutils.cpp
@@ -28,6 +28,10 @@
 
 using boost::math::iround;
 
+namespace {
+	bool shuttingDown = false;
+}
+
 QImage RenderUtils::renderPagePart(QSharedPointer< const Poppler::Page > page, QSize targetSize, PagePart whichPart)
 {
   if ( ! page )
@@ -35,6 +39,9 @@ QImage RenderUtils::renderPagePart(QSharedPointer< const Poppler::Page > page, Q
     throw std::runtime_error( QApplication::translate("RenderUtils", "RenderUtils::renderPagePart called with null page. Target size was %1x%2").
       arg(targetSize.width()).arg(targetSize.height()).toStdString() );
   }
+
+  if ( shuttingDown )
+    return QImage();
 
   /* pagesize in points, (72 points is an inch) */
   QSizeF pagesize = page->pageSizeF();
@@ -80,4 +87,8 @@ QImage RenderUtils::renderPagePart(QSharedPointer< const Poppler::Page > page, Q
 		      );
 
   return renderedImage;
+}
+
+void RenderUtils::notifyShutdown(void) {
+	shuttingDown = true;
 }

--- a/renderutils.cpp
+++ b/renderutils.cpp
@@ -28,7 +28,7 @@
 
 using boost::math::iround;
 
-QImage RenderUtils::renderPagePart(QSharedPointer< Poppler::Page > page, QSize targetSize, PagePart whichPart)
+QImage RenderUtils::renderPagePart(QSharedPointer< const Poppler::Page > page, QSize targetSize, PagePart whichPart)
 {
   if ( ! page )
   {

--- a/renderutils.h
+++ b/renderutils.h
@@ -33,6 +33,12 @@ public:
 
   /** Since only the static functions of this class are used, we do not need to construct instances */
   RenderUtils() =delete;
+
+  /** Notifies about impending shutdown.
+   *
+   * All further render attempts will return null images.
+   */
+  static void notifyShutdown(void);
 };
 
 #endif // RENDERUTILS_H

--- a/renderutils.h
+++ b/renderutils.h
@@ -29,7 +29,7 @@
 class RenderUtils
 {
 public:
-  static QImage renderPagePart(QSharedPointer<Poppler::Page> page, QSize targetSize, PagePart whichPart);
+  static QImage renderPagePart(QSharedPointer<const Poppler::Page> page, QSize targetSize, PagePart whichPart);
 
   /** Since only the static functions of this class are used, we do not need to construct instances */
   RenderUtils() =delete;

--- a/runtimeconfiguration.cpp
+++ b/runtimeconfiguration.cpp
@@ -55,6 +55,7 @@ RuntimeConfiguration::RuntimeConfiguration(int argc, const char* const * argv):
 	m_filePath(),
 	m_hyperlinkSupport(true),
 	m_cacheToMemory(true),
+	m_cacheSizeMegaBytes(0),
 	m_useSecondScreen(true),
 	m_i3workaround(false),
 	m_prerenderPreviousPages(3),
@@ -102,6 +103,12 @@ RuntimeConfiguration::RuntimeConfiguration(int argc, const char* const * argv):
      "Cache the PDF file into memory\n"
      "Useful if you are editing the PDF file with latex while using the presenter software.").toLocal8Bit()
      )
+	("cache-size",
+		value<unsigned>(&m_cacheSizeMegaBytes)->default_value(1024),
+		tr(
+			"Size of the cache for pre-rendered pages, in megabytes."
+		).toLocal8Bit()
+	)
     ("i3-workaround",
      value<bool>(&m_i3workaround)->default_value(false),
 	 tr(
@@ -339,4 +346,12 @@ std::string RuntimeConfiguration::i3workaround_shellcode() const
 PagePart RuntimeConfiguration::thumbnailPagePart() const
 {
 	return m_thumbnailPagePart;
+}
+
+unsigned RuntimeConfiguration::cacheSizeBytes() const {
+	return cacheSizeMegaBytes()*1024*1024;
+}
+
+unsigned RuntimeConfiguration::cacheSizeMegaBytes() const{
+	return m_cacheSizeMegaBytes;
 }

--- a/runtimeconfiguration.cpp
+++ b/runtimeconfiguration.cpp
@@ -295,9 +295,11 @@ bool RuntimeConfiguration::useSecondScreen() const
   return m_useSecondScreen;
 }
 
-bool RuntimeConfiguration::cachePDFToMemory() const
+PDFCacheOption RuntimeConfiguration::cacheSetting() const
 {
-  return m_cacheToMemory;
+  return m_cacheToMemory?
+	PDFCacheOption::keepPDFinMemory :
+	PDFCacheOption::rereadFromDisk;
 }
 
 unsigned int RuntimeConfiguration::bottomPaneHeight() const

--- a/runtimeconfiguration.h
+++ b/runtimeconfiguration.h
@@ -25,6 +25,7 @@
 #include <QString>
 #include <stdexcept>
 #include "pagepart.h"
+#include "pdfcacheoption.h"
 
 struct noFileNameException: public std::logic_error {
 	noFileNameException();
@@ -134,7 +135,7 @@ public:
 
   bool useSecondScreen() const;
 
-  bool cachePDFToMemory() const;
+  PDFCacheOption cacheSetting() const;
 
   unsigned bottomPaneHeight() const;
   bool hyperlinkSupport() const;

--- a/runtimeconfiguration.h
+++ b/runtimeconfiguration.h
@@ -73,6 +73,9 @@ class RuntimeConfiguration: public QObject
   /** Shall the complete PDF be read into memory */
   bool m_cacheToMemory;
 
+  /** Size of the pre-render-cache in megabytes */
+  unsigned m_cacheSizeMegaBytes;
+
   /** Single-Display mode
    *
    * If True, there is only the audience display, the presenter's screen will remain hidden
@@ -132,6 +135,9 @@ public:
 
   unsigned prerenderPreviousPages() const;
   unsigned prerenderNextPages() const;
+
+  unsigned cacheSizeMegaBytes() const;
+  unsigned cacheSizeBytes() const;
 
   bool useSecondScreen() const;
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -25,6 +25,11 @@ if(DownloadTestPDF)
 		SHOW_PROGESS
 		EXPECTED_MD5 5c72e0954d457e3e9a1287ff299e307a
 		)
+	file(DOWNLOAD http://danny-edel.de/many-many-pages.pdf ${CMAKE_CURRENT_BINARY_DIR}/many-many-pages.pdf
+		TIMEOUT 30
+		SHOW_PROGRESS
+		EXPECTED_MD5 22d934fbc13a93adc5e91bfec866229e
+		)
 else()
 	# Compile from source
 	find_program(PDFLATEX

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(testhelp
 list(APPEND PDFFILENAMES
 	colored-rectangles.pdf
 	images.pdf
+	many-many-pages.pdf
 )
 
 if(DownloadTestPDF)

--- a/testing/pdfs/many-many-pages.tex
+++ b/testing/pdfs/many-many-pages.tex
@@ -1,0 +1,29 @@
+\documentclass[aspectratio=169]{beamer}
+\usepackage{color}
+\usepackage{pgfpages}
+\usepackage{pgffor}
+
+\setbeameroption{show notes on second screen}
+
+\title{Many, Many, Many pages.}
+
+\begin{document}
+
+
+
+\definecolor{8f8}{HTML}{88FF88}
+\definecolor{f8f}{HTML}{FF88FF}
+
+\foreach \n in {1,...,100}{
+
+\begingroup
+	\setbeamercolor{background canvas}{bg=8f8}
+	\setbeamercolor{note page}{bg=f8f}
+	\begin{frame}
+		Page \thepage
+	\end{frame}
+\endgroup
+
+}
+
+\end{document}


### PR DESCRIPTION
This should fix #140 - not only on windows.

* This PR adds a command line switch `--cache-size`, which is enforced by QCache.
  * While the current memory usage estimate is rather dumb (`32bit * width * height`) it does serve to prevent limitless growth.
* This avoids creating one `Poppler::Document` per thread, instead adding a `mutex` to a creation section and let the threads share a `QSharedPointer<Poppler::Document const>`.
* Also adds a WARNINGOUT macro, similar to DEBUGOUT.
* If there are `RenderThreads` still waiting to start and the application is shut down, they will now fail their rendering instantly. (The user won't see it anyway...)