### PR TITLE
Make Qt5 the default, deprecate qt4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_AUTORCC OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(UseQtFive "Build with Qt5 and libpoppler-qt5" OFF)
+option(UseQtFive "Build with Qt5 and libpoppler-qt5" ON)
 option(UpdateTranslations "Do you want to update the .ts files (WARNING: running make clean will delete them!)" OFF)
 option(BuildTests "Build unit tests (this requires pdflatex or internet access and DownloadTestPDFs=ON)" ON)
 option(BoostStaticLink "Link statically against the boost libraries" OFF)

--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -108,6 +108,9 @@ if(UseQtFive)
 else()
 	#qt4
 	message(STATUS "Using Qt4 and libpoppler-qt4")
+	message(WARNING "Qt4 support is deprecated and will be removed in the next version. "
+		"Please build dspdfviewer using Qt5. "
+		"If that does not work correctly on your platform, please file a bug!")
 	find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
 	pkg_search_module(POPPLER REQUIRED poppler-qt4)
 


### PR DESCRIPTION
I will drop Qt4 support in v1.16.

So make the default Qt mode Qt5, and use v1.15 to make sure it works as intended on all supported platforms.