### PR TITLE
Add dependencies so that static compilation works.

### DIFF
--- a/cmake/external_libraries.cmake
+++ b/cmake/external_libraries.cmake
@@ -37,7 +37,7 @@ if(UseQtFive)
 		# Try to find Qt in /qt/static/qtbase
 		# or plain /qt/static
 		set(CMAKE_PREFIX_PATH
-			"/Qt/static/qtbase;/Qt/static;${CMAKE_PREFIX_PATH}")
+			"/Qt/static/qtbase;/Qt/static;/Qt/static/qttools;${CMAKE_PREFIX_PATH}")
 	endif()
 	find_package(Qt5Core 5.1.1 REQUIRED)
 	# On lower versions, QTBUG-32100 prevents compilation at least on clang
@@ -45,6 +45,7 @@ if(UseQtFive)
 	find_package(Qt5Gui REQUIRED)
 	find_package(Qt5Widgets REQUIRED)
 	find_package(Qt5LinguistTools REQUIRED)
+	find_package(Qt5Xml REQUIRED)
 	message(STATUS "Found Qt5 at ${Qt5Core_DIR}")
 
 	if(MSVC)
@@ -75,6 +76,7 @@ if(UseQtFive)
 		${Qt5Gui_LIBRARIES}
 		${Qt5Widgets_LIBRARIES}
 		${Qt5LinguistTools_LIBRARIES}
+		${Qt5Xml_LIBRARIES}
 	)
 
 	# add their include directories
@@ -83,6 +85,7 @@ if(UseQtFive)
 		${Qt5Gui_INCLUDE_DIRS}
 		${Qt5Widgets_INCLUDE_DIRS}
 		${Qt5LinguistTools_INCLUDE_DIRS}
+		${Qt5Xml_INCLUDE_DIRS}
 	)
 
 	# Set conditional compilation to Qt5 mode

--- a/cmake/filelists.cmake
+++ b/cmake/filelists.cmake
@@ -79,6 +79,15 @@ list(APPEND WINDOWS_PRECOMPILED_STATIC_LIBRARIES
 	"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/MSImg32.Lib"
 	"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/Imm32.Lib"
 	"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Lib/Winmm.Lib"
+	# Qt Platform Support
+	optimized "C:/Qt/Static/qtbase/lib/Qt5PlatformSupport.lib"
+	debug "C:/Qt/Static/qtbase/lib/Qt5PlatformSupportd.lib"
+	optimized "C:/Qt/Static/qtbase/lib/qtharfbuzzng.lib"
+	debug "C:/Qt/Static/qtbase/lib/qtharfbuzzngd.lib"
+	optimized "C:/Qt/Static/qtbase/lib/qtpcre.lib"
+	debug "C:/Qt/Static/qtbase/lib/qtpcred.lib"
+	optimized "C:/Qt/Static/qtbase/plugins/platforms/qwindows.lib"
+	debug "C:/Qt/Static/qtbase/plugins/platforms/qwindowsd.lib"
 )
 
 list(APPEND WINDOWS_PRECOMPILED_DYNAMIC_LIBRARIES


### PR DESCRIPTION
- qttools is required for LinguistTools
- Xml is one of the additional dependencies that can be found automatically
- Qt does not provide cmake files for PlatformSupport, harfbuzzng, pcre and windows, so I hardcoded them

With those dependencies, this branch succeeds compilation and execution.