### PR TITLE
Compiler/GNU-GCC: Test for c++11 flag, not version

### DIFF
--- a/cmake/compiler_gnu_gcc.cmake
+++ b/cmake/compiler_gnu_gcc.cmake
@@ -1,28 +1,23 @@
 # GNU GCC
 
-# Found on
-# http://stackoverflow.com/questions/10984442/how-to-detect-c11-support-of-a-compiler-with-cmake
-#
-# Identify GCC version
-execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+include(CheckCXXCompilerFlag)
 
-# GCC >= 4.7 supports -std=c++11 argument
-if (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-	message(STATUS "GNU GCC 4.7 or higher detected.")
-	add_definitions("-std=c++11")
-
-# On GCC >= 4.3 it is supported as -std=c++0x, but some things aren't supported
-# yet (this will fail later on when compiling)
-elseif(GCC_VERSION VERSION_GREATER 4.3 OR GCC_VERSION VERSION_EQUAL 4.3)
-	message(WARNING "You are using an old version of gcc."
-		" Consider upgrading to a more recent version if you run into problems.")
-	add_definitions("-std=c++0x")
-
-# Even older version: Fail now.
-else ()
-	message(FATAL_ERROR "C++11 needed. For GCC that means a version higher than 4.3 is needed.")
+CHECK_CXX_COMPILER_FLAG("-std=c++11" C11FLAG)
+if(C11FLAG)
+	message(STATUS "Compiler supports -std=c++11, using it.")
+	add_definitions(-std=c++11)
+else()
+	message(WARNING "Compiler does not support -std=c++11, trying c++0x")
+	CHECK_CXX_COMPILER_FLAG("-std=c++0x" C0XFLAG)
+	if(C0XFLAG)
+		message(STATUS "Using -std=c++0x")
+		add_definitions(-std=c++0x)
+	else()
+		message(FATAL_ERROR "Compiler does not support -std=c++0x either. "
+			"Please upgrade your compiler."
+			)
+	endif()
 endif()
-
 
 # Set as much warnings as possible.
 add_definitions(


### PR DESCRIPTION
This completely replaces the version-number-based detection for c++11
support, and simply tries the command line switches "-std=c++11" and
"-std=c++0x" in order.

fixes #151 