### PR TITLE
Fake debian/ folder: Update to qt5 build-dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,22 +1,25 @@
 Source: dspdfviewer
 Section: text
-Priority: extra
+Priority: optional
 Maintainer: Danny Edel <mail@danny-edel.de>
 Build-Depends: cmake,
-               debhelper (>= 7.3.0),
-               g++ (>= 4:4.6),
+               debhelper (>= 9.20120417),
                latex-beamer,
+               libboost-dev,
                libboost-program-options-dev,
                libboost-test-dev,
-               libpoppler-qt4-dev,
-               lsb-release,
+               libpoppler-qt5-dev,
                pkg-config,
+               qtbase5-dev,
+               qttools5-dev,
+               qttools5-dev-tools,
+               texlive-latex-recommended,
                texlive-pictures,
                xauth,
                xvfb
-Standards-Version: 3.9.3
-Vcs-Git: git://github.com/dannyedel/dspdfviewer.git
-Vcs-Browser: https://github.com/dannyedel/dspdfviewer
+Standards-Version: 3.9.6
+Vcs-Git: git://anonscm.debian.org/collab-maint/dspdfviewer.git
+Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/dspdfviewer.git
 Homepage: http://dspdfviewer.danny-edel.de
 
 Package: dspdfviewer
@@ -42,14 +45,3 @@ Description: Dual-Screen PDF Viewer for LaTeX-beamer
  Also, on the second screen, you get page thumbnails and status
  information, like the time since you started the presentation
  and a "wall clock".
-
-Package: dspdfviewer-dbg
-Section: debug
-Priority: extra
-Architecture: any
-Depends: dspdfviewer (= ${binary:Version}), ${misc:Depends}
-Description: debugging symbols for dspdfviewer
- dspdfviewer if a specialized PDF viewer for latex-beamer
- presentations using the "shot notes on second screen" feature.
- .
- This package contains the debugging symbols for dspdfviewer.

--- a/debian/rules
+++ b/debian/rules
@@ -1,46 +1,21 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
-# Uncomment this to turn on verbose mode.
-export DH_VERBOSE=1
+# Enable build hardening
+export DEB_BUILD_MAINT_OPTIONS=hardening=+all
+DPKG_EXPORT_BUILDFLAGS=1
+include /usr/share/dpkg/buildflags.mk
 
-# enable hardening
-export DEB_BUILD_HARDENING=1
 
-# Make sure to NOT use any flags from environment and only use the standard
-# debian build flags.
+# provide debian version number to the build system
 #
-# include CPPFLAGS in CFLAGS, this is a cmake workaround found on
-# https://wiki.debian.org/Hardening#Notes_for_packages_using_CMake
-export CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
-export CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) $(CPPFLAGS)
-export CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS) $(CPPFLAGS)
-export LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
-
-VERSION=$(shell dpkg-parsechangelog | sed -n 's/^Version: //p')
-
+# Rationale: dspdfviewer --version embeds the information that this
+# is from the debian package. This is useful when users go
+# directly to the github-issue-tracker instead of using reportbug.
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDSPDFVIEWER_VERSION=$(VERSION)
+	dh_auto_configure -- \
+		-DDSPDFVIEWER_VERSION=$(shell dpkg-parsechangelog --show-field Version) \
+		-DUseQtFive=ON
 
-
-# Debug package building
-.PHONY: override_dh_strip
-override_dh_strip:
-	dh_strip --dbg-package=dspdfviewer-dbg
-
-override_dh_auto_install:
-	dh_auto_install --destdir=debian/dspdfviewer
-
-override_dh_installdocs:
-	dh_installdocs --link-doc=dspdfviewer
-
-
-# Use debhelper for the rest
 %:
-	dh $@
+	dh $@ --parallel


### PR DESCRIPTION
These are the d/rules and d/control from the official Debian packaging.