### PR TITLE
appveyor.yml: Build and test a Debug configuration aswell

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,14 +17,14 @@ before_build:
     - cmd: mkdir \projects\dspdfviewer\build
     - cmd: cd \projects\dspdfviewer\build
     - cmd: >
-      cmake ..
-      -G "Visual Studio 12 2013"
-      -DUseQtFive=ON
-      -DDownloadTestPDF=ON
-      -DBoostStaticLink=ON
-      -DWindowsStaticLink=OFF
-      -DBOOST_ROOT=\libraries\boost
-      -DBOOST_LIBRARYDIR=\libraries\boost\lib32-msvc-12.0
+        cmake ..
+        -G "Visual Studio 12 2013"
+        -DUseQtFive=ON
+        -DDownloadTestPDF=ON
+        -DBoostStaticLink=ON
+        -DWindowsStaticLink=OFF
+        -DBOOST_ROOT=\libraries\boost
+        -DBOOST_LIBRARYDIR=\libraries\boost\lib32-msvc-12.0
 
 build:
   project: C:\projects\dspdfviewer\build\dspdfviewer.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -50,6 +50,7 @@ before_test:
     - cmd: SET PATH=%PATH%;C:\qt\5.5\msvc2013\bin
     - cmd: if exist Testing\Debug copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\Debug\poppler-qt5.dll
     - cmd: if exist Testing\Debug copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\poppler-qt5.dll
+    - cmd: SET CTEST_OUTPUT_ON_FAILURE=1
 
 after_test:
     - cmd: msbuild RUN_TESTS.vcxproj

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,35 +2,34 @@ version: '{build}'
 branches:
   only:
   - master
-  - /^windows-test.*/
+  - /^test-.*/
 os: Visual Studio 2013
+configuration: Debug, Release
 
-# Before build: Download and extract dependency package
-before_build:
-  # Allow password-based authentication to RDP
-  # this is needed for rdesktop to work later on
-- cmd: reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
-  # Download and extract dependencies
+# Before anything else: Download and extract dependency package
+init:
 - ps: (new-object net.webclient).DownloadFile('https://github.com/projekter/dspdfviewer/releases/download/v1.14-42-g4acfb31/DependenciesDyn.rar', 'c:\dependencies.rar')
 - cmd: cd \
 - cmd: 7z x \dependencies.rar
 
-# Build with cmake
-build_script:
-- cmd: cd \projects\dspdfviewer
-- cmd: mkdir build
-- cmd: cd build
-- cmd: >
-    cmake ..
-    -G "Visual Studio 12 2013"
-    -DUseQtFive=ON
-    -DDownloadTestPDF=ON
-    -DCMAKE_VERBOSE_MAKEFILE=ON
-    -DBoostStaticLink=ON
-    -DWindowsStaticLink=OFF
-    -DBOOST_ROOT=\libraries\boost
-    -DBOOST_LIBRARYDIR=\libraries\boost\lib32-msvc-12.0
-- cmd: cmake --build . --config Release
+# Before build: Let CMake create the solution file
+before_build:
+    - cmd: mkdir \projects\dspdfviewer\build
+    - cmd: cd \projects\dspdfviewer\build
+    - cmd: >
+      cmake ..
+      -G "Visual Studio 12 2013"
+      -DUseQtFive=ON
+      -DDownloadTestPDF=ON
+      -DBoostStaticLink=ON
+      -DWindowsStaticLink=OFF
+      -DBOOST_ROOT=\libraries\boost
+      -DBOOST_LIBRARYDIR=\libraries\boost\lib32-msvc-12.0
+
+build:
+  project: C:\projects\dspdfviewer\build\dspdfviewer.sln
+  parallel: true
+  verbosity: detailed
 
 before_test:
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\deps\cairo\bin
@@ -46,10 +45,8 @@ before_test:
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\deps\zlib\bin
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\poppler\bin
     - cmd: SET PATH=%PATH%;C:\qt\5.5\msvc2013\bin
+    - cmd: copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\Debug\poppler-qt5.dll
+    - cmd: copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\poppler-qt5.dll
 
-test_script:
-    - cmd: ctest -C Release --output-on-failure --timeout 30
-
-# Un-Comment this to get an RDP shell when something fails
-#on_failure:
-#    - ps: '$blockRdp = $true; iex ((new-object net.webclient).DownloadString(''https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1''))'
+after_test:
+    - cmd: msbuild RUN_TESTS.vcxproj

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,8 +48,8 @@ before_test:
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\deps\zlib\bin
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\poppler\bin
     - cmd: SET PATH=%PATH%;C:\qt\5.5\msvc2013\bin
-    - cmd: copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\Debug\poppler-qt5.dll
-    - cmd: copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\poppler-qt5.dll
+    - cmd: if exist Testing\Debug copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\Debug\poppler-qt5.dll
+    - cmd: if exist Testing copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\poppler-qt5.dll
 
 after_test:
     - cmd: msbuild RUN_TESTS.vcxproj

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,9 @@ branches:
   - master
   - /^test-.*/
 os: Visual Studio 2013
-configuration: Debug, Release
+configuration:
+  - Debug
+  - Release
 
 # Before anything else: Download and extract dependency package
 init:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,7 @@ init:
 - ps: (new-object net.webclient).DownloadFile('https://github.com/projekter/dspdfviewer/releases/download/v1.14-42-g4acfb31/DependenciesDyn.rar', 'c:\dependencies.rar')
 - cmd: cd \
 - cmd: 7z x \dependencies.rar
+- cmd: cd \projects\dspdfviewer
 
 # Before build: Let CMake create the solution file
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ before_test:
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\poppler\bin
     - cmd: SET PATH=%PATH%;C:\qt\5.5\msvc2013\bin
     - cmd: if exist Testing\Debug copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\Debug\poppler-qt5.dll
-    - cmd: if exist Testing copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\poppler-qt5.dll
+    - cmd: if exist Testing\Debug copy C:\dspdf\popplerDyn\poppler\bin\poppler-qt5d.dll Testing\poppler-qt5.dll
 
 after_test:
     - cmd: msbuild RUN_TESTS.vcxproj


### PR DESCRIPTION
This PR adds the copy command necessary to load the .dll into the compiled program's folder.

Also adds some minor cleanups to the appveyor.yml file, dropping RDP and try to use MSBuild whenever possible.

fixes #154 