### PR TITLE
Correctly set -DQT_NO_DEBUG_OUTPUT

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,6 @@ before_build:
 build:
   project: C:\projects\dspdfviewer\build\dspdfviewer.sln
   parallel: true
-  verbosity: detailed
 
 before_test:
     - cmd: SET PATH=%PATH%;C:\dspdf\popplerDyn\deps\cairo\bin

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -26,13 +26,11 @@ endif()
 ### Common for all compilers
 #
 
-# Disable debug info unless we're in debugmode.
-if( "${CMAKE_BUILD_TYPE}" MATCHES "^Debug$" )
-  # do nothing
-else()
-  add_definitions(-DQT_NO_DEBUG_OUTPUT)
-endif()
+# Add -DQT_NO_DEBUG_OUTPUT to Release
+# and Release with Debug Info builds
 
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DQT_NO_DEBUG_OUTPUT")
 
 # This helps with translation, since it disables QString(const char*)
 add_definitions(-DQT_NO_CAST_FROM_ASCII)


### PR DESCRIPTION
Checkout CMAKE_BUILD_TYPE does not work with multi-configuration
generators, such as the MSBuild generator used on windows.