### PR TITLE
Set timeouts on unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if(BuildTests)
 	# Run unit tests regardless of debug/release
 	# Set a default timeout to 60 seconds
 	set(DART_TESTING_TIMEOUT 60)
+	set(CTEST_TEST_TIMEOUT 60)
 	include(CTest)
 	add_subdirectory(testing)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ target_link_libraries(dspdfviewer libdspdfviewer)
 ### ... and link it with the tests to produce a testing executable.
 if(BuildTests)
 	# Run unit tests regardless of debug/release
+	# Set a default timeout to 60 seconds
+	set(DART_TESTING_TIMEOUT 60)
 	include(CTest)
 	add_subdirectory(testing)
 endif()

--- a/_travis/test
+++ b/_travis/test
@@ -9,6 +9,3 @@ if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
 else
 	ctest --output-on-failure --timeout 60
 fi
-
-# print coverage report, ignore errors
-ctest -T coverage || true

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -136,7 +136,6 @@ if(UseQtFive)
 		)
 		set_tests_properties(testswapscreen
 			PROPERTIES
-				TIMEOUT 60
 				SKIP_RETURN_CODE 77
 		)
 	endif()


### PR DESCRIPTION
Use a default testing timeout, instead of error-prone per-test timeouts.

This is mainly useful for windows, where a missing DLL will spawn a warning window that needs to be clicked away.