### PR TITLE
Travis/Codecov: Fix integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,11 @@ install:
 script: _travis/test
 after_success:
     - pip install --user codecov
-    - PATH="$HOME/.local/bin:$PATH" codecov
+    - >
+        if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then
+          ~/Library/Python/*/bin/codecov ;
+        elif [[ "$CXX" == "clang++" ]] ; then
+          ~/.local/bin/codecov --gcov-exec llvm-cov ;
+        else
+          ~/.local/bin/codecov ;
+        fi


### PR DESCRIPTION
Make sure the correct codecov binary gets called, and that it uses llvm-cov when appropriate.

* OSX: Give the correct path to the user library
* Linux/Clang: Use llvm-cov instead of gcov
* Linux/GCC: Call ~/.local/bin/codecov directly