### PR TITLE
AppVeyor/MSVC: Use Windows XP toolset

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ before_build:
     - cmd: cd \projects\dspdfviewer\build
     - cmd: >
         cmake ..
-        -G "Visual Studio 12 2013"
+        -G "Visual Studio 12 2013" -T v120_xp
         -DUseQtFive=ON
         -DUsePrerenderedPDF=ON
         -DBoostStaticLink=ON


### PR DESCRIPTION
This should™ only use Windows functions that are also available on Windows XP.

If nothing else, this allows me to run dspdfviewer under [ReactOS][1] and WinXP VM's which need *a lot* less system resources than Win7 or higher.  So far, I have not seen any indicator that something would not work.

This has no effect on *compiling* dspdfviewer, since MSVC2013 won't run on XP.

[1]: https://reactos.org/