### PR TITLE
travis: also build against Qt5 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ matrix:
         - os: osx
           compiler: clang
           before_install: _travis/osx-install-dependencies
+        - os: osx
+          compiler: clang
+          env: QT_VERSION=5
+          before_install: _travis/osx-install-dependencies
 install:
     - _travis/configure
     - make -C build

--- a/_travis/configure
+++ b/_travis/configure
@@ -30,6 +30,14 @@ if [ "$QT_VERSION" -eq 4 ] ; then
 	CMAKE_PARAMETERS+=" -DUseQtFive=OFF"
 elif [ "$QT_VERSION" -eq 5 ] ; then
 	CMAKE_PARAMETERS+=" -DUseQtFive=ON"
+	if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+		# on OSX/Homebrew, qt5 is not in default search path yet.
+		#
+		# Use shell-glob to find the qt5 directory
+		# and pass it to cmake
+		QT5PATH=$(ls -d /usr/local/Cellar/qt5/5.*/ | head -n1 )
+		CMAKE_PARAMETERS+=" -DCMAKE_PREFIX_PATH=$QT5PATH"
+	fi
 else
 	echo "Unknown qt version $QT_VERSION" >&2
 	false

--- a/_travis/configure
+++ b/_travis/configure
@@ -33,9 +33,8 @@ elif [ "$QT_VERSION" -eq 5 ] ; then
 	if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
 		# on OSX/Homebrew, qt5 is not in default search path yet.
 		#
-		# Use shell-glob to find the qt5 directory
-		# and pass it to cmake
-		QT5PATH=$(ls -d /usr/local/Cellar/qt5/5.*/ | head -n1 )
+		# Use brew to find the qt5 prefix and pass it to cmake.
+		QT5PATH=$(brew --prefix qt5)
 		CMAKE_PARAMETERS+=" -DCMAKE_PREFIX_PATH=$QT5PATH"
 	fi
 else


### PR DESCRIPTION
In #174 it was discovered there are problems when compiling Qt5 on OS X.  Use travis to verify *building* against Qt5 works.