### PR TITLE
Travis/OSX: Use latest XCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ debian/*.log
 # stuff from jekyll after building the website
 _site/
 vendor
+.sass-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,11 @@ matrix:
               apt:
                   packages: *q5dep
         - os: osx
+          osx_image: xcode7.3
           compiler: clang
           before_install: _travis/osx-install-dependencies
         - os: osx
+          osx_image: xcode7.3
           compiler: clang
           env: QT_VERSION=5
           before_install: _travis/osx-install-dependencies

--- a/cmake/compiler_clang.cmake
+++ b/cmake/compiler_clang.cmake
@@ -32,6 +32,9 @@ endif()
 # TODO: Set this only for the automoc files
 add_definitions(-Wno-error=undefined-reinterpret-cast)
 
+# Clang on recent XCode fails to compile the boost tests
+add_definitions(-Wno-error=disabled-macro-expansion)
+
 #message(FATAL_ERROR "Version: ${CMAKE_CXX_COMPILER_VERSION}")
 
 # clang will complain about -isystem passed but not used.


### PR DESCRIPTION
Maybe™ the problem in #174 was because of the more recent compiler version.  Make travis use the `xcode7.3` image in order to test this.