### PR TITLE
Travis-CI:  Use container-based trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,12 @@ matrix:
     include:
         - compiler: clang
         - dist: trusty
-          sudo: required
           env: QT_VERSION=5
           compiler: gcc
           addons:
               apt:
                   packages: *q5dep
         - dist: trusty
-          sudo: required
           env: QT_VERSION=5
           compiler: clang
           addons:


### PR DESCRIPTION
This should speed up things by using a container-based (instead of a
fully virtualized) trusty image on CI builds.

See https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/
for more information.