### PR TITLE
Travis-CI: Try more recent compilers with docker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# GitHub code owner file
+#
+# This decides who gets asked for a review on the code
+#
+# By default, ask @dannyedel for a review
+
+*  @dannyedel
+
+# FIXME: Add more specific categories

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,6 @@ matrix:
               apt:
                   packages: *q5dep
         - os: osx
-          compiler: clang
-          before_install: _travis/osx-install-dependencies
-        - os: osx
           osx_image: xcode7.3
           compiler: clang
           env: QT_VERSION=5

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,13 @@ branches:
         - /^test-.*$/
 # Build matrix.
 #
-# The first (implicit) build will be
-# qt4/gcc/container-based (precise)
-#
-# additional builds specified are
-# 2. qt4/clang/container (precise)
-# 3. qt5/gcc/gce (sudo/trusty)
-# 4. qt5/clang/gce (sudo/trusty)
-# 5. osx/clang
+# 1. qt4/gcc @ precise
+# 2. qt4/clang @ precise
+# 3. qt5/gcc @ trusty
+# 4. qt5/clang @ trusty
+# 5. qt5/clang @ osx (default xcode)
+# 6. qt5/gcc7 and clang-5.0 @ buster
+# 7. qt5/gcc8 and clang-6.0 @ sid/experimental
 matrix:
     include:
         - dist: precise
@@ -61,7 +60,6 @@ matrix:
               apt:
                   packages: *q5dep
         - os: osx
-          osx_image: xcode7.3
           compiler: clang
           env: QT_VERSION=5
           before_install: _travis/osx-install-dependencies
@@ -69,7 +67,14 @@ matrix:
           addons:
               apt:
                   packages:
-          env: BUILDMETHOD=docker
+          env: BUILDMETHOD=docker DEBDIST=buster
+          script:  _travis/docker/build-and-test-software
+          install: _travis/docker/build-docker-image
+        - services: docker
+          addons:
+              apt:
+                  packages:
+          env: BUILDMETHOD=docker DEBDIST=experimental
           script:  _travis/docker/build-and-test-software
           install: _travis/docker/build-docker-image
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,14 +67,14 @@ matrix:
           addons:
               apt:
                   packages:
-          env: BUILDMETHOD=docker DEBDIST=buster
+          env: DEBDIST=buster
           script:  _travis/docker/build-and-test-software
           install: _travis/docker/build-docker-image
         - services: docker
           addons:
               apt:
                   packages:
-          env: BUILDMETHOD=docker DEBDIST=experimental
+          env: DEBDIST=experimental
           script:  _travis/docker/build-and-test-software
           install: _travis/docker/build-docker-image
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ branches:
 # 5. osx/clang
 matrix:
     include:
-        - compiler: clang
+        - dist: precise
+          compiler: gcc
+        - dist: precise
+          compiler: clang
         - dist: trusty
           sudo: required
           env: QT_VERSION=5

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
           addons:
               apt:
                   packages:
+          env: BUILDMETHOD=docker
           script:  _travis/docker/build-and-test-software
           install: _travis/docker/build-docker-image
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,12 @@ matrix:
           compiler: clang
           env: QT_VERSION=5
           before_install: _travis/osx-install-dependencies
+        - services: docker
+          addons:
+              apt:
+                  packages:
+          script:  _travis/docker/build-and-test-software
+          install: _travis/docker/build-docker-image
 install:
     - _travis/configure
     - make -C build

--- a/_travis/docker/Dockerfile-buster
+++ b/_travis/docker/Dockerfile-buster
@@ -3,10 +3,8 @@ MAINTAINER Danny Edel <mail@danny-edel.de>
 
 RUN echo deb-src http://deb.debian.org/debian buster main >> /etc/apt/sources.list
 
-RUN apt-get update -y && apt-get upgrade -yV
+RUN apt-get update -y && apt-get install eatmydata -yV && eatmydata apt-get upgrade -yV
 
-RUN apt-get build-dep -y dspdfviewer
+RUN eatmydata apt-get build-dep -y dspdfviewer
 
-RUN apt-get install -yV clang-5.0
-
-RUN apt-get install -yV xvfb xauth
+RUN eatmydata apt-get install -yV clang-5.0

--- a/_travis/docker/Dockerfile-buster
+++ b/_travis/docker/Dockerfile-buster
@@ -1,0 +1,12 @@
+FROM debian:buster
+MAINTAINER Danny Edel <mail@danny-edel.de>
+
+RUN echo deb-src http://deb.debian.org/debian buster main >> /etc/apt/sources.list
+
+RUN apt-get update -y && apt-get upgrade -yV
+
+RUN apt-get build-dep -y dspdfviewer
+
+RUN apt-get install -yV clang-5.0
+
+RUN apt-get install -yV xvfb xauth

--- a/_travis/docker/Dockerfile-experimental
+++ b/_travis/docker/Dockerfile-experimental
@@ -1,0 +1,12 @@
+FROM debian:experimental
+MAINTAINER Danny Edel <mail@danny-edel.de>
+
+RUN echo deb-src http://deb.debian.org/debian sid main >> /etc/apt/sources.list
+
+RUN apt-get update -y && apt-get install eatmydata -yV && eatmydata apt-get upgrade -yV
+
+RUN apt-get build-dep -y dspdfviewer
+
+RUN apt-get install -yV clang-6.0
+
+RUN apt-get install -yV g++-8 -t experimental

--- a/_travis/docker/build-and-test-software
+++ b/_travis/docker/build-and-test-software
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -evx
+
+SOURCECODE="$PWD"
+
+# Uses the Debian image with the recent compilers installed to
+# build once against g++ and once against clang.
+
+# FIXME:  Does not run the actual testsuite yet
+
+# Pass 1:  g++
+docker run -it --rm -v "$SOURCECODE:/source:ro" \
+	dspdfviewer-build /source/_travis/docker/test-gcc
+
+# Pass 2:  clang
+docker run -it --rm -v "$SOURCECODE:/source:ro" \
+	dspdfviewer-build /source/_travis/docker/test-clang

--- a/_travis/docker/build-and-test-software
+++ b/_travis/docker/build-and-test-software
@@ -3,6 +3,7 @@
 set -evx
 
 SOURCECODE="$PWD"
+: "${DEBDIST:=buster}"
 
 # Uses the Debian image with the recent compilers installed to
 # build once against g++ and once against clang.
@@ -11,8 +12,8 @@ SOURCECODE="$PWD"
 
 # Pass 1:  g++
 docker run -it --rm -v "$SOURCECODE:/source:ro" \
-	dspdfviewer-build /source/_travis/docker/test-gcc
+	"dspdfviewer-build-$DEBDIST" /source/_travis/docker/test-gcc
 
 # Pass 2:  clang
 docker run -it --rm -v "$SOURCECODE:/source:ro" \
-	dspdfviewer-build /source/_travis/docker/test-clang
+	"dspdfviewer-build-$DEBDIST" /source/_travis/docker/test-clang

--- a/_travis/docker/build-docker-image
+++ b/_travis/docker/build-docker-image
@@ -2,4 +2,4 @@
 
 DOCKERDIR="$(dirname "$0")"
 
-docker build -t dspdfviewer-build -f "$DOCKERDIR/Dockerfile-buster" "$DOCKERDIR"
+docker build --pull=true -t dspdfviewer-build -f "$DOCKERDIR/Dockerfile-buster" "$DOCKERDIR"

--- a/_travis/docker/build-docker-image
+++ b/_travis/docker/build-docker-image
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DOCKERDIR="$(dirname "$0")"
+
+docker build -t dspdfviewer-build -f "$DOCKERDIR/Dockerfile-buster" "$DOCKERDIR"

--- a/_travis/docker/build-docker-image
+++ b/_travis/docker/build-docker-image
@@ -2,4 +2,6 @@
 
 DOCKERDIR="$(dirname "$0")"
 
-docker build --pull=true -t dspdfviewer-build -f "$DOCKERDIR/Dockerfile-buster" "$DOCKERDIR"
+: "${DEBDIST:=buster}"
+
+docker build --pull=true -t "dspdfviewer-build-$DEBDIST" -f "$DOCKERDIR/Dockerfile-$DEBDIST" "$DOCKERDIR"

--- a/_travis/docker/compile
+++ b/_travis/docker/compile
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -evx
+
+mkdir /build
+cd /build
+cmake /source -DUsePrerenderedPDF=ON
+make -k

--- a/_travis/docker/test-clang
+++ b/_travis/docker/test-clang
@@ -2,7 +2,22 @@
 
 set -evx
 
-export CC=clang-5.0
-export CXX=clang++-5.0
+# find highest installed clang version
+TEST_CLANG_VERSIONS="7.0 6.0 5.0 4.0 3.8"
+
+for i in $TEST_CLANG_VERSIONS ; do
+	if which "clang-$i" &>/dev/null ; then
+		export CC=clang-$i
+		export CXX=clang++-$i
+		break
+	fi
+done
+
+# Fallback to unversioned binary
+if [ -z "$CC" ] ; then
+	export CC=clang
+	export CXX=clang++
+fi
+
 
 exec "$(dirname "$0")"/compile

--- a/_travis/docker/test-clang
+++ b/_travis/docker/test-clang
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -evx
+
+export CC=clang-5.0
+export CXX=clang++-5.0
+
+exec "$(dirname "$0")"/compile

--- a/_travis/docker/test-gcc
+++ b/_travis/docker/test-gcc
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -evx
+
+export CC=gcc
+export CXX=g++
+
+exec "$(dirname "$0")"/compile

--- a/_travis/docker/test-gcc
+++ b/_travis/docker/test-gcc
@@ -2,7 +2,22 @@
 
 set -evx
 
-export CC=gcc
-export CXX=g++
+# find highest installed gcc version
+TEST_GCC_VERSIONS="9 8 7 6"
+
+for i in $TEST_GCC_VERSIONS ; do
+	if which "gcc-$i" &>/dev/null ; then
+		export CC=gcc-$i
+		export CXX=g++-$i
+		break
+	fi
+done
+
+# Fallback to unversioned binary
+if [ -z "$CC" ] ; then
+	export CC=gcc
+	export CXX=g++
+fi
+
 
 exec "$(dirname "$0")"/compile

--- a/cmake/compiler_clang.cmake
+++ b/cmake/compiler_clang.cmake
@@ -35,6 +35,25 @@ add_definitions(-Wno-error=undefined-reinterpret-cast)
 # Clang on recent XCode fails to compile the boost tests
 add_definitions(-Wno-error=disabled-macro-expansion)
 
+# Clang-5.0 notices this on runtimeconfiguration.cpp:201:14
+#
+# 'boost::program_options::parse_config_file<char>' required here, but no
+# definition is available [-Werror,-Wundefined-func-template]
+# store( parse_config_file( cfile, configFileOptions), vm);
+#
+# FIXME: This is a workaround, not a solution.
+# See #191 at https://github.com/dannyedel/dspdfviewer/issues/191
+#
+# Older clang versions (at least including clang-3.8) abort compilation
+# with this flag, so first check if this current version supports it.
+Include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-Wno-error=undefined-func-template"
+	CLANG_SUPPORTS_UNDEFINED_FUNC_TEMPLATE_DIAGNOSTIC)
+if(CLANG_SUPPORTS_UNDEFINED_FUNC_TEMPLATE_DIAGNOSTIC)
+	# Add the command-l
+	add_definitions(-Wno-error=undefined-func-template)
+endif()
+
 #message(FATAL_ERROR "Version: ${CMAKE_CXX_COMPILER_VERSION}")
 
 # clang will complain about -isystem passed but not used.

--- a/cmake/compiler_clang.cmake
+++ b/cmake/compiler_clang.cmake
@@ -54,7 +54,20 @@ if(CLANG_SUPPORTS_UNDEFINED_FUNC_TEMPLATE_DIAGNOSTIC)
 	add_definitions(-Wno-error=undefined-func-template)
 endif()
 
-#message(FATAL_ERROR "Version: ${CMAKE_CXX_COMPILER_VERSION}")
+# Clang-6.0 notices this on the auto-generated moc files:
+#
+# moc_dspdfviewer.cpp:[many times]: error: redundant parentheses
+# surrounding declarator [-Werror,-Wredundant-parens]
+#
+# Since this is auto-generated code by Qt, we just demote the error
+# to warning.
+#
+# FIXME: Limit this to *only* the auto-generated code.
+CHECK_CXX_COMPILER_FLAG("-Wno-error=redundant-parens"
+	CLANG_SUPPORTS_REDUNDANT_PARENS_DIAGNOSTIC)
+if(CLANG_SUPPORTS_REDUNDANT_PARENS_DIAGNOSTIC)
+	add_definitions(-Wno-error=redundant-parens)
+endif()
 
 # clang will complain about -isystem passed but not used.
 # This adds unnecessary noise

--- a/cmake/compiler_gnu_gcc.cmake
+++ b/cmake/compiler_gnu_gcc.cmake
@@ -41,6 +41,18 @@ if( NOT UseQtFive )
 	add_definitions(-Wno-error=effc++)
 endif()
 
+# on GCC 8, compilation fails on the Qt auto-generated code
+# file moc_dspdfviewerwindow.cpp with errors like these:
+#
+# error: unnecessary parentheses in declaration of 'type name' [-Werror=parentheses]
+#
+# FIXME: Limit this to the auto-generated files only
+CHECK_CXX_COMPILER_FLAG("-Wno-error=parentheses"
+	GCC_SUPPORTS_PARENTHESES_DIAGNOSTIC)
+if(GCC_SUPPORTS_PARENTHESES_DIAGNOSTIC)
+	add_definitions(-Wno-error=parentheses)
+endif()
+
 if(CodeCoverage)
 	message(STATUS "Adding gcov as test coverage helper")
 	add_definitions(-fprofile-arcs -ftest-coverage -O0)

--- a/hyperlinkarea.cpp
+++ b/hyperlinkarea.cpp
@@ -32,7 +32,7 @@ HyperlinkArea::HyperlinkArea(QLabel* imageLabel, const AdjustedLink& link): QLab
     throw WrongLinkType();
   QRect mySize;
   const QPixmap* pixmap = imageLabel->pixmap();
-  if ( pixmap == 0 )
+  if ( pixmap == nullptr )
     throw /** FIXME Exception **/ std::runtime_error("Tried to construct a HyperlinkArea from an image label without a pixmap");
   
   QRectF sizeWithinImageLabel = link.linkArea();


### PR DESCRIPTION
In order to reproduce #191 I created a local docker image with clang-5.0.

This PR includes that docker images definition and a small wrapper script to make travis build the image, and then try to compile dspdfviewer inside the docker container.