### PR TITLE
Reset slide clock whenever slide changes

### DIFF
--- a/dspdfviewer.cpp
+++ b/dspdfviewer.cpp
@@ -132,14 +132,12 @@ DSPDFViewer::~DSPDFViewer()
 
 void DSPDFViewer::goBackward()
 {
-  resetSlideClock();
   if ( pageNumber() > 0 )
     gotoPage(pageNumber()-1);
 }
 
 void DSPDFViewer::goForward()
 {
-  resetSlideClock();
   if ( pageNumber() < numberOfPages()-1 )
     gotoPage(pageNumber()+1);
 }
@@ -200,6 +198,7 @@ void DSPDFViewer::gotoPage(unsigned int pageNumber)
   if ( m_pagenumber != pageNumber
       && numberOfPages() > pageNumber )
   {
+    resetSlideClock();
     m_pagenumber = pageNumber;
     renderPage();
   } else {


### PR DESCRIPTION
Jumping to another slide with the G shortcut would leave the old slide's clock running rather than restarting.